### PR TITLE
Add API details to folder docs

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,27 @@
+# Assets
+
+## Why
+All artwork and future audio are stored here. Godot imports files automatically so keeping them organised avoids bloating the repository with unused resources.
+
+## Responsibilities
+- Hold card illustrations in `cards/`.
+- Keep UI icons like gold, mana or status effects in `ui/`.
+- Record licences for any third party art or sound.
+
+## Usage Notes
+Use PNGs at power-of-two sizes so textures scale well. When adding new icons, create both the image and its `.import` file by dropping it into the Godot editor. If the asset comes from an external artist, document the licence and source in this README or a text file next to the asset.
+
+## Key Files
+| Folder | Content |
+|-------|---------|
+| `cards/` | frames such as `forest_card.png` and `neutral_structure.png` |
+| `ui/` | icons including `gold.png`, `mana.png`, `burn.png` |
+
+## Example
+```gdscript
+var tex = load("res://assets/cards/forest_card.png")
+```
+
+Large sprite sheets or sounds should live in a subfolder and be referenced by a scene so they are loaded only when necessary. Keeping this folder clean helps reduce build size and keeps git history manageable.
+
+When removing outdated art, also delete the `.import` metadata to prevent orphan entries inside `project.godot`. Keep an eye on repository size; using texture compression in the import settings helps maintain a small footprint during version control.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,28 @@
+# Data
+
+## Why
+This folder stores JSON files that describe all cards and other content. The game loads them on startup so designers can tweak values without touching code.
+
+## Responsibilities
+- Maintain `card_data.json` containing stats, costs and seasonal effects.
+- Allow new biomes or card types to be added through simple JSON entries.
+- Provide an import path for future editor or mod tools.
+
+## Key Schema
+`card_data.json` has two root dictionaries:
+- `neutral_structures`: basic structures always present in the market.
+- `biome_cards`: a set of lists indexed by biome name.
+Each card entry includes fields like `id`, `name`, `type`, `atk`, `hp` and a map of `effects` that the `EffectProcessor` can understand.
+
+When the file grows large, keep cards grouped by biome and sorted alphabetically to avoid merge conflicts. Non designers should refrain from hand editing values during playtesting; use the editor or a dedicated script to modify cards.
+
+## Example
+```gdscript
+var json_text = FileAccess.open("res://data/card_data.json", FileAccess.READ).get_as_text()
+var data = JSON.parse_string(json_text)
+print(data.biome_cards.keys())
+```
+
+Future expansions may include creature animations or localisation strings which would live beside the card file. Use similar schema conventions so `CardDatabase` can load them reliably.
+
+Card lists here are version controlled so changes can be reviewed. When balancing seasons, submit small focused edits so playtesters can track which tweaks affect difficulty.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Documentation
+
+## Why
+High level design material lives here so new contributors can quickly understand the architecture. Keeping docs close to the code base avoids losing context over time.
+
+## Responsibilities
+- Provide architecture overviews and dependency diagrams.
+- Maintain a glossary of deck-building and strategy terms.
+- Record Architectural Decision Records (ADRs) for major changes.
+
+## Structure
+- `architecture.md` explains how managers interact and includes diagrams. Update it when adding or refactoring systems.
+- `glossary.md` lists short definitions of important game terminology.
+- `adr/` holds numbered ADR files that justify design choices such as chosen network protocol or UI toolkit.
+
+Each document should be concise so the folder remains readable. When implementing a new feature, check if any diagrams need updates and add an ADR entry if the change alters the project's direction.
+
+## Example Outline
+```md
+# architecture.md
+- GameManager orchestrates SeasonManager and BoardManager.
+- NetworkManager handles lobby then relays RPC to GameManager.
+```
+
+Thorough documentation saves time during onboarding and ensures gameplay behaviour is reproducible. Keep commit messages and ADRs in sync so there is a clear history of why systems exist.
+
+Regularly review this folder when planning sprints. Outdated diagrams lead to confusion during playtesting and can slow down onboarding. Keeping notes accurate helps maintain design coherence across code and content.

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -1,0 +1,28 @@
+# Scenes
+
+## Why
+Scenes describe the node hierarchy for menus, gameplay and popups. They remain light and rely on scripts in sibling folders for logic.
+
+## Responsibilities
+- Provide entry points such as `MainMenu.tscn` and `LobbyMenu.tscn`.
+- Host the main gameplay tree in `Main.tscn` with `GameManager` as root.
+- Include UI fragments like `BoardUI.tscn`, `HandUI.tscn` and shop dialogs.
+- Supply tutorial overlays that appear during the first run.
+
+## Flow
+`MainMenu.tscn` loads first and lets the player choose solo, network or tutorial. In multiplayer the `LobbyMenu.tscn` waits until enough peers join before moving to `Main.tscn`. During a match the board and terrain are spawned under `GameManager`. Dialogs for the market and biome shop are instantiated only when opened, keeping the scene tree lean.
+
+## Key Scenes
+| Scene | Purpose |
+|------|---------|
+| `MainMenu.tscn` | Buttons to start solo or online mode. |
+| `LobbyMenu.tscn` | Connects peers and displays player list. |
+| `Main.tscn` | Contains battle board and managers. |
+| `MarketDialog.tscn` | Popup for the neutral auction house. |
+
+## Example Usage
+```gdscript
+get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+```
+
+Scenes rarely contain code beyond hooking up their child nodes. When adding a new scene, keep scripts minimal and delegate behaviour to a manager in `scripts/` or UI controller in `ui/` so the structure stays maintainable.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# Scripts
+
+## Why
+This folder collects all gameplay logic. Each GDScript stays loaded so managers can coordinate turns, AI and networking across scenes.
+
+## Responsibilities
+- Orchestrate players and seasons via `GameManager`, `SeasonManager` and `BattleManager`.
+- Handle card data, decks and in-game effects.
+- Provide AI behaviours and multiplayer RPCs through `NetworkManager`.
+- Offer small helpers such as `Logger` and `SaveManager`.
+
+## Public APIs
+| File | Functions | Effect on game |
+|------|-----------|----------------|
+| `battle_manager.gd` | `destroy(card)`, `unit_vs_unit(a,d)`, `full_attack(att,def)` | Resolve combat and remove dead units. |
+| `biome_shop.gd` | `buy(player, idx)` | Give a biome card to the player. |
+| `board_manager.gd` | `init_board(players)`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()` | Maintain board grid and unit lists. |
+| `card.gd` | `copy()->Card`, `damage(v)` | Duplicate card or apply damage. |
+| `card_database.gd` | `neutral()`, `biome(b)` | Provide card templates. |
+| `deck.gd` | `shuffle()`, `draw_n(n)->Array`, `add(card)` | Manage player deck ordering. |
+| `effect_processor.gd` | `apply(effect, src, tgt)` | Execute card effect dictionaries. |
+| `event_bus.gd` | `emit(tag, payload={})` | Broadcast global events. |
+| `game_manager.gd` | `remote_play_card(id,owner)`, `remote_end_turn(owner)` | Remote players interact via RPC. |
+| `logger.gd` | `info(msg)`, `warn(msg)`, `error(msg)` | Simple logging facility. |
+| `market_manager.gd` | `open()`, `bid(player,amt)`, `close()` | Handle shop bidding rounds. |
+| `network_manager.gd` | `rpc_play_card(id,owner)`, `rpc_end_turn(owner)` | Forward network RPC to GameManager. |
+| `player.gd` | `draw(n)`, `start_turn()`, `end_turn()`, `opponent()`, `summon_token(name,atk,hp)`, `consume_token(name,eff,val)`, `take_direct_dmg(v)` | Manage a player's resources and board presence. |
+| `save_manager.gd` | `save_run(state)`, `load_run()->Dictionary` | Persist or load run state. |
+| `season_manager.gd` | `reset()`, `current()`, `advance_segment()` | Cycle through seasons and emit signals. |
+| `terrain_manager.gd` | `init(players)`, `season_update(season)` | Spawn and update terrain tiles. |
+| `terrain_tile.gd` | `apply_season(season)` | Change tile visuals per season. |
+| `tutorial_manager.gd` | `start()`, `on_action(tag)` | Drive tutorial step by step. |
+| `ai_pro.gd`, `ai_swarm.gd` | *(no public API)* | Internal AI routines. |
+
+## Example
+```gdscript
+var gm := GameManager.new()
+add_child(gm)
+SeasonManager.connect("season_start", Callable(self, "_on_season_start"))
+```

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,29 @@
+# UI
+
+## Why
+User interface scripts and scenes live here. They connect nodes to game managers via signals so that the board, shop and menus always reflect current gameplay.
+
+## Responsibilities
+- Render a player's hand, battlefield and shops (`HandUI`, `BoardUI`, `BiomeShopUI`).
+- Provide menus for solo and network play (`MainMenu`, `LobbyMenu`).
+- Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
+- Present tutorial hints through `TutorialOverlay`.
+
+`HandUI`, `BoardUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes.
+
+## Public APIs
+Only `TutorialOverlay` exposes calls so other nodes can show or hide tips when needed.
+
+| File | Functions | Effect on game |
+|------|-----------|----------------|
+| `tutorial_overlay.gd` | `show_tip(msg)`, `hide()` | Display or remove an instructional popup. |
+| Other UI scripts | *(no public functions)* | They update visuals when notified via signals. |
+
+## Example
+```gdscript
+var overlay := TutorialOverlay.new()
+add_child(overlay)
+overlay.show_tip("Drag a card")
+```
+
+Even without direct APIs, these scripts form the backbone of the player's experience. Any future additions to the HUD or dialogs should follow the same pattern: emit a signal from gameplay code, listen here, and update nodes in `ready` or signal callbacks.


### PR DESCRIPTION
## Summary
- expand every module README to target 200+ tokens
- document public functions for each script file
- clarify UI scripts and scene flow
- outline JSON schema and asset usage
- describe documentation folder purpose

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68544baa559c8326be7ce15444212ae6