### PR TITLE
Remove code examples in READMEs

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -17,10 +17,6 @@ Use PNGs at power-of-two sizes so textures scale well. When adding new icons, cr
 | `cards/` | frames such as `forest_card.png` and `neutral_structure.png` |
 | `ui/` | icons including `gold.png`, `mana.png`, `burn.png` |
 
-## Example
-```gdscript
-var tex = load("res://assets/cards/forest_card.png")
-```
 
 Large sprite sheets or sounds should live in a subfolder and be referenced by a scene so they are loaded only when necessary. Keeping this folder clean helps reduce build size and keeps git history manageable.
 

--- a/data/README.md
+++ b/data/README.md
@@ -16,12 +16,6 @@ Each card entry includes fields like `id`, `name`, `type`, `atk`, `hp` and a map
 
 When the file grows large, keep cards grouped by biome and sorted alphabetically to avoid merge conflicts. Non designers should refrain from hand editing values during playtesting; use the editor or a dedicated script to modify cards.
 
-## Example
-```gdscript
-var json_text = FileAccess.open("res://data/card_data.json", FileAccess.READ).get_as_text()
-var data = JSON.parse_string(json_text)
-print(data.biome_cards.keys())
-```
 
 Future expansions may include creature animations or localisation strings which would live beside the card file. Use similar schema conventions so `CardDatabase` can load them reliably.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,13 +15,10 @@ High level design material lives here so new contributors can quickly understand
 
 Each document should be concise so the folder remains readable. When implementing a new feature, check if any diagrams need updates and add an ADR entry if the change alters the project's direction.
 
-## Example Outline
-```md
-# architecture.md
-- GameManager orchestrates SeasonManager and BoardManager.
-- NetworkManager handles lobby then relays RPC to GameManager.
-```
 
 Thorough documentation saves time during onboarding and ensures gameplay behaviour is reproducible. Keep commit messages and ADRs in sync so there is a clear history of why systems exist.
 
 Regularly review this folder when planning sprints. Outdated diagrams lead to confusion during playtesting and can slow down onboarding. Keeping notes accurate helps maintain design coherence across code and content.
+
+## Usage
+Consult these documents before major refactors or feature additions. They act as the project's reference point for architecture and terminology.

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -20,9 +20,5 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 | `Main.tscn` | Contains battle board and managers. |
 | `MarketDialog.tscn` | Popup for the neutral auction house. |
 
-## Example Usage
-```gdscript
-get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
-```
 
 Scenes rarely contain code beyond hooking up their child nodes. When adding a new scene, keep scripts minimal and delegate behaviour to a manager in `scripts/` or UI controller in `ui/` so the structure stays maintainable.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,29 +12,23 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 ## Public APIs
 | File | Functions | Effect on game |
 |------|-----------|----------------|
-| `battle_manager.gd` | `destroy(card)`, `unit_vs_unit(a,d)`, `full_attack(att,def)` | Resolve combat and remove dead units. |
-| `biome_shop.gd` | `buy(player, idx)` | Give a biome card to the player. |
-| `board_manager.gd` | `init_board(players)`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()` | Maintain board grid and unit lists. |
-| `card.gd` | `copy()->Card`, `damage(v)` | Duplicate card or apply damage. |
-| `card_database.gd` | `neutral()`, `biome(b)` | Provide card templates. |
-| `deck.gd` | `shuffle()`, `draw_n(n)->Array`, `add(card)` | Manage player deck ordering. |
-| `effect_processor.gd` | `apply(effect, src, tgt)` | Execute card effect dictionaries. |
-| `event_bus.gd` | `emit(tag, payload={})` | Broadcast global events. |
-| `game_manager.gd` | `remote_play_card(id,owner)`, `remote_end_turn(owner)` | Remote players interact via RPC. |
-| `logger.gd` | `info(msg)`, `warn(msg)`, `error(msg)` | Simple logging facility. |
-| `market_manager.gd` | `open()`, `bid(player,amt)`, `close()` | Handle shop bidding rounds. |
-| `network_manager.gd` | `rpc_play_card(id,owner)`, `rpc_end_turn(owner)` | Forward network RPC to GameManager. |
-| `player.gd` | `draw(n)`, `start_turn()`, `end_turn()`, `opponent()`, `summon_token(name,atk,hp)`, `consume_token(name,eff,val)`, `take_direct_dmg(v)` | Manage a player's resources and board presence. |
-| `save_manager.gd` | `save_run(state)`, `load_run()->Dictionary` | Persist or load run state. |
-| `season_manager.gd` | `reset()`, `current()`, `advance_segment()` | Cycle through seasons and emit signals. |
-| `terrain_manager.gd` | `init(players)`, `season_update(season)` | Spawn and update terrain tiles. |
-| `terrain_tile.gd` | `apply_season(season)` | Change tile visuals per season. |
-| `tutorial_manager.gd` | `start()`, `on_action(tag)` | Drive tutorial step by step. |
+| `battle_manager.gd` | `destroy(card)->void`, `unit_vs_unit(a,d)->void`, `full_attack(att,def)->void` | Resolve combat and remove dead units. |
+| `biome_shop.gd` | `buy(player, idx)->void` | Give a biome card to the player. |
+| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Maintain board grid and unit lists. |
+| `card.gd` | `copy()->Card`, `damage(v)->void` | Duplicate card or apply damage. |
+| `card_database.gd` | `neutral()->Array`, `biome(b)->Array` | Provide card templates. |
+| `deck.gd` | `shuffle()->void`, `draw_n(n)->Array`, `add(card)->void` | Manage player deck ordering. |
+| `effect_processor.gd` | `apply(effect, src, tgt)->void` | Execute card effect dictionaries. |
+| `event_bus.gd` | `emit(tag, payload={})->void` | Broadcast global events. |
+| `game_manager.gd` | `remote_play_card(id,owner)->void`, `remote_end_turn(owner)->void` | Remote players interact via RPC. |
+| `logger.gd` | `info(msg)->void`, `warn(msg)->void`, `error(msg)->void` | Simple logging facility. |
+| `market_manager.gd` | `open()->void`, `bid(player,amt)->void`, `close()->void` | Handle shop bidding rounds. |
+| `network_manager.gd` | `rpc_play_card(id,owner)->void`, `rpc_end_turn(owner)->void` | Forward network RPC to GameManager. |
+| `player.gd` | `draw(n)->void`, `start_turn()->void`, `end_turn()->void`, `opponent()->Player`, `summon_token(name,atk,hp)->void`, `consume_token(name,eff,val)->void`, `take_direct_dmg(v)->void` | Manage a player's resources and board presence. |
+| `save_manager.gd` | `save_run(state)->void`, `load_run()->Dictionary` | Persist or load run state. |
+| `season_manager.gd` | `reset()->void`, `current()->String`, `advance_segment()->void` | Cycle through seasons and emit signals. |
+| `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void` | Spawn and update terrain tiles. |
+| `terrain_tile.gd` | `apply_season(season)->void` | Change tile visuals per season. |
+| `tutorial_manager.gd` | `start()->void`, `on_action(tag)->void` | Drive tutorial step by step. |
 | `ai_pro.gd`, `ai_swarm.gd` | *(no public API)* | Internal AI routines. |
 
-## Example
-```gdscript
-var gm := GameManager.new()
-add_child(gm)
-SeasonManager.connect("season_start", Callable(self, "_on_season_start"))
-```

--- a/ui/README.md
+++ b/ui/README.md
@@ -19,11 +19,5 @@ Only `TutorialOverlay` exposes calls so other nodes can show or hide tips when n
 | `tutorial_overlay.gd` | `show_tip(msg)`, `hide()` | Display or remove an instructional popup. |
 | Other UI scripts | *(no public functions)* | They update visuals when notified via signals. |
 
-## Example
-```gdscript
-var overlay := TutorialOverlay.new()
-add_child(overlay)
-overlay.show_tip("Drag a card")
-```
 
 Even without direct APIs, these scripts form the backbone of the player's experience. Any future additions to the HUD or dialogs should follow the same pattern: emit a signal from gameplay code, listen here, and update nodes in `ready` or signal callbacks.


### PR DESCRIPTION
## Summary
- strip the example code blocks from all READMEs
- clarify return types in `scripts/README.md`
- add brief usage note in `docs/README.md`

## Testing
- `echo "No tests present" && true`

------
https://chatgpt.com/codex/tasks/task_e_68545eec1b1483269e4ceec749ec3669