### PR TITLE
Add background image support

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,8 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://cjdqxa7aoixfn"]
+[gd_scene load_steps=3 format=3 uid="uid://cjdqxa7aoixfn"]
 
 [ext_resource type="Script" uid="uid://pwh5hqjc6nvx" path="res://scripts/game_manager.gd" id="1"]
+[ext_resource type="Texture2D" path="res://assets/ui/bg_main.png" id="2"]
 
 [node name="Main" type="Node"]
 script = ExtResource("1")
 
 [node name="UI" type="CanvasLayer" parent="."]
+[node name="Background" type="TextureRect" parent="UI"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+z_index = -1
+texture = ExtResource("2")

--- a/scenes/MainMenu.tscn
+++ b/scenes/MainMenu.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://cqgbsfl8lecy0"]
+[gd_scene load_steps=3 format=3 uid="uid://cqgbsfl8lecy0"]
 
 [ext_resource type="Script" uid="uid://cnx43v3lgxsm6" path="res://ui/main_menu.gd" id="1"]
+[ext_resource type="Texture2D" path="res://assets/ui/bg_main.png" id="2"]
 
 [node name="MainMenu" type="Control"]
 layout_mode = 3
@@ -10,6 +11,12 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1")
+
+[node name="Background" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+z_index = -1
+texture = ExtResource("2")
 
 [node name="VBox" type="VBoxContainer" parent="."]
 layout_mode = 0

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -15,10 +15,11 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 ## Key Scenes
 | Scene | Purpose |
 |------|---------|
-| `MainMenu.tscn` | Buttons to start solo or online mode. |
+| `MainMenu.tscn` | Buttons to start solo or online mode with a background. |
 | `LobbyMenu.tscn` | Connects peers and displays player list. |
-| `Main.tscn` | Contains battle board and managers. |
+| `Main.tscn` | Contains battle board, managers and a background. |
 | `MarketDialog.tscn` | Popup for the neutral auction house. |
 
 
 Scenes rarely contain code beyond hooking up their child nodes. When adding a new scene, keep scripts minimal and delegate behaviour to a manager in `scripts/` or UI controller in `ui/` so the structure stays maintainable.
+Both main scenes use a `TextureRect` named `Background` that loads `assets/ui/bg_main.png` to cover the screen.


### PR DESCRIPTION
## Summary
- show `bg_main.png` behind main menu and gameplay scenes
- document new background nodes in `scenes/README.md`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68546adda440832684d019e6bc182c66