### PR TITLE
Add StatsUI and player stats updates

### DIFF
--- a/scenes/StatsUI.tscn
+++ b/scenes/StatsUI.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=2 format=3 uid="uid://statsui"]
+
+[ext_resource type="Script" path="res://ui/stats_ui.gd" id="1"]
+
+[node name="StatsUI" type="HBoxContainer"]
+anchors_preset = -1
+anchor_right = 1.0
+script = ExtResource("1")
+
+[node name="Life" type="Label" parent="."]
+text = "Life:"
+
+[node name="Gold" type="Label" parent="."]
+text = "Gold:"
+
+[node name="Essence" type="Label" parent="."]
+text = "Essence:"
+
+[node name="Mana" type="Label" parent="."]
+text = "Mana:"

--- a/scripts/biome_shop.gd
+++ b/scripts/biome_shop.gd
@@ -18,6 +18,7 @@ func buy(p:Player, idx:int):
 	var c := stock[idx]
 	p.gold    -= 4
 	p.essence -= 2
+	p.emit_stats()
 	p.deck.add(c.copy())
 	stock.remove_at(idx)
 	emit_signal("bought", p, c)

--- a/scripts/effect_processor.gd
+++ b/scripts/effect_processor.gd
@@ -11,7 +11,9 @@ func apply(e : Dictionary, src : Card, tgt = null) -> void:
 		"poison":        tgt.status.poison += e.value
 		"draw":          src.owner.draw(e.value)
 		"mana":          src.owner.mana += e.value
+		src.owner.emit_stats()
 		"gain_gold":     src.owner.gold += e.value
+		src.owner.emit_stats()
 		"charge":        src.charge += e.value
 		"blast":
 			if tgt: tgt.damage(e.value * src.charge)

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -47,6 +47,9 @@ func _spawn_players() -> void:
 func _init_ui() -> void:
 	var ui := $UI
 	for p in players:
+			var stats := preload("res://scenes/StatsUI.tscn").instantiate()
+			stats.player_path = p.get_path()
+			ui.add_child(stats)
 			var hand := preload("res://scenes/HandUI.tscn").instantiate()
 			hand.player_path = p.get_path()
 			ui.add_child(hand)

--- a/scripts/market_manager.gd
+++ b/scripts/market_manager.gd
@@ -25,7 +25,8 @@ func close():
 	var win:Player = null; var high := -1
 	for p in bids: if bids[p] > high: high = bids[p]; win = p
 	if win:
-		win.gold -= high
-		win.structures.append(current)
+			win.gold -= high
+			win.emit_stats()
+			win.structures.append(current)
 	emit_signal("auction_close", current, win)
 	current = null

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -4,6 +4,7 @@ class_name Player
 signal turn_end(p : Player)
 signal defeated(p : Player)
 signal hand_changed(p : Player)          # ← nouveau signal
+signal stats_changed(p : Player)
 
 @export var biome    : String = "Forest"
 @export var is_human : bool   = true
@@ -18,6 +19,9 @@ var units       : Array[Card] = []
 var structures  : Array[Card] = []
 var tokens      : Dictionary  = {}
 
+func emit_stats() -> void:
+	emit_signal("stats_changed", self)
+
 func _ready() -> void:
 	add_child(deck)
 	var starter : Array = CardDatabase.biome(biome)
@@ -25,7 +29,8 @@ func _ready() -> void:
 	deck.add(starter[1].copy())
 	for i in 8:
 		deck.add(CardDatabase.neutral()[0].copy())
-	deck.shuffle()
+        deck.shuffle()
+	emit_stats()
 
 func draw(n : int) -> void:
 	hand += deck.draw_n(n)
@@ -35,6 +40,7 @@ func start_turn() -> void:
 	Logger.info("start_turn")
 	mana = 3
 	draw(5)
+	emit_stats()
 	if !is_human:
 		_ai_play()
 
@@ -65,6 +71,7 @@ func consume_token(name:String, eff:String, val:int) -> void:
 
 func take_direct_dmg(v:int) -> void:
 	life -= v
+	emit_stats()
 	if life <= 0:
 		emit_signal("defeated", self)
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -5,11 +5,12 @@ User interface scripts and scenes live here. They connect nodes to game managers
 
 ## Responsibilities
 - Render a player's hand, battlefield and shops (`HandUI`, `BoardUI`, `BiomeShopUI`).
+- Display resources such as life and gold (`StatsUI`).
 - Provide menus for solo and network play (`MainMenu`, `LobbyMenu`).
 - Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
 - Present tutorial hints through `TutorialOverlay`.
 
-`HandUI`, `BoardUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080. These size changes are skipped when running from the editor to avoid "Embedded window" warnings.
+`HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080. These size changes are skipped when running from the editor to avoid "Embedded window" warnings.
 
 ## Public APIs
 Only `TutorialOverlay` exposes calls so other nodes can show or hide tips when needed.

--- a/ui/stats_ui.gd
+++ b/ui/stats_ui.gd
@@ -1,0 +1,17 @@
+extends HBoxContainer
+class_name StatsUI
+
+@export var player_path : NodePath
+var player : Player
+
+func _ready() -> void:
+	player = get_node(player_path)
+	player.add_to_group("local_player")
+	player.connect("stats_changed", Callable(self, "_refresh"))
+	_refresh()
+
+func _refresh(_p : Player = null) -> void:
+	$Life.text = "Life: %d" % player.life
+	$Gold.text = "Gold: %d" % player.gold
+	$Essence.text = "Essence: %d" % player.essence
+	$Mana.text = "Mana: %d" % player.mana


### PR DESCRIPTION
## Summary
- show player stats in the HUD
- fire new `stats_changed` signal from `Player`
- update gold and mana sources
- spawn StatsUI in `GameManager`
- document StatsUI usage

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685490061be08326ab5725526a99a2c0