### PR TITLE
Enable fullscreen mode inside editor

### DIFF
--- a/scenes/README.md
+++ b/scenes/README.md
@@ -11,7 +11,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 
 ## Flow
 
-`MainMenu.tscn` loads first and lets the player choose solo, network or tutorial. Menus display in a 1280×720 window so the game launches in a compact mode. In multiplayer the `LobbyMenu.tscn` waits until enough peers join before moving to `Main.tscn`. When a match begins, the window switches to exclusive fullscreen at 1920×1080. These size changes are disabled inside the editor to avoid "Embedded window" errors. During play the board and terrain are spawned under `GameManager`. Dialogs for the market and biome shop are instantiated only when opened, keeping the scene tree lean.
+`MainMenu.tscn` loads first and lets the player choose solo, network or tutorial. Menus display in a 1280×720 window so the game launches in a compact mode. In multiplayer the `LobbyMenu.tscn` waits until enough peers join before moving to `Main.tscn`. When a match begins, the window switches to exclusive fullscreen at 1920×1080. During play the board and terrain are spawned under `GameManager`. Dialogs for the market and biome shop are instantiated only when opened, keeping the scene tree lean.
 
 ## Key Scenes
 | Scene | Purpose |

--- a/ui/README.md
+++ b/ui/README.md
@@ -10,7 +10,7 @@ User interface scripts and scenes live here. They connect nodes to game managers
 - Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
 - Present tutorial hints through `TutorialOverlay`.
 
-`HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080. These size changes are skipped when running from the editor to avoid "Embedded window" warnings.
+`HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.
 
 ## Public APIs
 Only `TutorialOverlay` exposes calls so other nodes can show or hide tips when needed.

--- a/ui/lobby_menu.gd
+++ b/ui/lobby_menu.gd
@@ -10,10 +10,10 @@ class_name LobbyMenu
 
 var net : NetworkManager = null
 
+
 func _ready() -> void:
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-		DisplayServer.window_set_size(Vector2i(1280, 720))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	DisplayServer.window_set_size(Vector2i(1280, 720))
 	start_btn.disabled = true
 	players_lbl.text   = "Players: 1"
 	status_lbl.text    = "Idle"
@@ -55,9 +55,8 @@ func _on_ready() -> void:
 
 # ------------------------------------------------------------- démarrer partie
 func _on_StartButton_pressed() -> void:
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-		DisplayServer.window_set_size(Vector2i(1920, 1080))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+	DisplayServer.window_set_size(Vector2i(1920, 1080))
 	var main := preload("res://scenes/Main.tscn").instantiate()
 	get_tree().root.add_child(main)
 	queue_free()

--- a/ui/main_menu.gd
+++ b/ui/main_menu.gd
@@ -6,32 +6,31 @@ class_name MainMenu
 @onready var tuto_btn   = $VBox/TutoButton
 @onready var quit_btn   = $VBox/QuitButton
 
+
+
+
 func _ready() -> void:
 	# Auto-connect des signaux si besoin
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-		DisplayServer.window_set_size(Vector2i(1280, 720))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	DisplayServer.window_set_size(Vector2i(1280, 720))
 	$VBox/SoloButton.pressed.connect(_on_SoloButton_pressed)
 	$VBox/MultiButton.pressed.connect(_on_MultiButton_pressed)
 	$VBox/TutoButton.pressed.connect(_on_TutoButton_pressed)
 	$VBox/QuitButton.pressed.connect(_on_QuitButton_pressed)
 
 func _on_SoloButton_pressed() -> void:
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-		DisplayServer.window_set_size(Vector2i(1920, 1080))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+	DisplayServer.window_set_size(Vector2i(1920, 1080))
 	get_tree().change_scene_to_file("res://scenes/Main.tscn")
 
 func _on_MultiButton_pressed() -> void:
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-		DisplayServer.window_set_size(Vector2i(1280, 720))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	DisplayServer.window_set_size(Vector2i(1280, 720))
 	get_tree().change_scene_to_file("res://scenes/LobbyMenu.tscn")
 
 func _on_TutoButton_pressed() -> void:
-	if not Engine.is_editor_hint():
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-		DisplayServer.window_set_size(Vector2i(1920, 1080))
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+	DisplayServer.window_set_size(Vector2i(1920, 1080))
 	var main := preload("res://scenes/Main.tscn").instantiate()
 	get_tree().root.add_child(main)
 	var tuto := preload("res://scripts/tutorial_manager.gd").new()


### PR DESCRIPTION
## Summary
- update `MainMenu` and `LobbyMenu` to always change window mode
- document fullscreen behaviour in UI and Scenes READMEs

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0768cf8832695b6db0285e652a5