### PR TITLE
Fix missing terrain and fullscreen issues

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://pwh5hqjc6nvx" path="res://scripts/game_manager.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://b01ci0pf8kb13" path="res://assets/ui/bg_main.png" id="2"]
 
-[node name="Main" type="Node"]
+[node name="Main" type="Node2D"]
 script = ExtResource("1")
 
 [node name="UI" type="CanvasLayer" parent="."]

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -5,7 +5,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 
 ## Responsibilities
 - Provide entry points such as `MainMenu.tscn` and `LobbyMenu.tscn`.
-- Host the main gameplay tree in `Main.tscn` with `GameManager` as root.
+- Host the main gameplay tree in `Main.tscn` with `GameManager` as a `Node2D` root so terrain and board visuals appear.
 - Include UI fragments like `BoardUI.tscn`, `HandUI.tscn` and shop dialogs.
 - Supply tutorial overlays that appear during the first run.
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Node2D
 class_name GameManager
 
 @export var biomes      : PackedStringArray = ["Forest", "Volcano"]

--- a/ui/lobby_menu.gd
+++ b/ui/lobby_menu.gd
@@ -55,8 +55,8 @@ func _on_ready() -> void:
 
 # ------------------------------------------------------------- démarrer partie
 func _on_StartButton_pressed() -> void:
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-	DisplayServer.window_set_size(Vector2i(1920, 1080))
-	var main := preload("res://scenes/Main.tscn").instantiate()
-	get_tree().root.add_child(main)
-	queue_free()
+        DisplayServer.window_set_size(Vector2i(1920, 1080))
+        DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+        var main := preload("res://scenes/Main.tscn").instantiate()
+        get_tree().root.add_child(main)
+        queue_free()

--- a/ui/main_menu.gd
+++ b/ui/main_menu.gd
@@ -19,9 +19,9 @@ func _ready() -> void:
 	$VBox/QuitButton.pressed.connect(_on_QuitButton_pressed)
 
 func _on_SoloButton_pressed() -> void:
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-	DisplayServer.window_set_size(Vector2i(1920, 1080))
-	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+        DisplayServer.window_set_size(Vector2i(1920, 1080))
+        DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+        get_tree().change_scene_to_file("res://scenes/Main.tscn")
 
 func _on_MultiButton_pressed() -> void:
 	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
@@ -29,8 +29,8 @@ func _on_MultiButton_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/LobbyMenu.tscn")
 
 func _on_TutoButton_pressed() -> void:
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-	DisplayServer.window_set_size(Vector2i(1920, 1080))
+        DisplayServer.window_set_size(Vector2i(1920, 1080))
+        DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
 	var main := preload("res://scenes/Main.tscn").instantiate()
 	get_tree().root.add_child(main)
 	var tuto := preload("res://scripts/tutorial_manager.gd").new()


### PR DESCRIPTION
## Summary
- change GameManager to a Node2D so 2D nodes render
- update Main.tscn root node type
- adjust fullscreen commands to set size first
- document Node2D root in scene overview

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b448ac908326a5b8a89cf7d80e62