### PR TITLE
Scale card icons with screen size

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -8,6 +8,8 @@ User interface scripts and scenes live here. They connect nodes to game managers
 - Display resources such as life and gold (`StatsUI`).
 - Provide menus for solo and network play (`MainMenu`, `LobbyMenu`).
 - Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
+- `CardButton` sizes icons based on the window (`size_ratio` export) and
+  sets `expand_icon` so large textures shrink to fit.
 - Present tutorial hints through `TutorialOverlay`.
 
 `HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.

--- a/ui/card_button.gd
+++ b/ui/card_button.gd
@@ -6,6 +6,9 @@ class_name CardButton
 
 var card_data : Card
 
+# Percentage of the screen width this button should occupy.
+@export var size_ratio : float = 0.1
+
 const CARD_TEXTURES := {
        "Forest": preload("res://assets/cards/forest_card.png"),
        "Desert": preload("res://assets/cards/desert_card.png"),
@@ -19,8 +22,11 @@ const CARD_TEXTURES := {
 signal dragged(card : Card)
 
 func _ready() -> void:
-	text = card_data.name
-	icon = CARD_TEXTURES.get(card_data.biome, CARD_TEXTURES["Neutral"])
+        text = card_data.name
+        icon = CARD_TEXTURES.get(card_data.biome, CARD_TEXTURES["Neutral"])
+        expand_icon = true
+        var width := get_viewport_rect().size.x * size_ratio
+        custom_minimum_size = Vector2(width, width * 1.5)
 
 func _gui_input(event : InputEvent) -> void:
 	if event is InputEventMouseButton \


### PR DESCRIPTION
## Summary
- add `size_ratio` export to `CardButton` and compute button size from viewport
- update `CardButton` icon scaling
- document new property in `ui/README.md`

## Testing
- `apt-get install -y file imagemagick` *(to inspect images)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b9126b448326b3413488fc78caad