### PR TITLE
Arrange UI layout

### DIFF
--- a/scenes/BoardUI.tscn
+++ b/scenes/BoardUI.tscn
@@ -4,5 +4,7 @@
 
 [node name="BoardUI" type="VBoxContainer"]
 anchors_preset = -1
-anchor_right = 0.5
+anchor_right = 1.0
+anchor_top = 0.1
+anchor_bottom = 0.8
 script = ExtResource("1")

--- a/scenes/HandUI.tscn
+++ b/scenes/HandUI.tscn
@@ -3,8 +3,9 @@
 [ext_resource type="Script" uid="uid://culmccxyh8kmh" path="res://ui/hand_ui.gd" id="1"]
 
 [node name="HandUI" type="HBoxContainer"]
-anchors_preset = 15
+anchors_preset = -1
 anchor_right = 1.0
+anchor_top = 0.8
 anchor_bottom = 1.0
 script = ExtResource("1")
 margin_right = 0.0

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -7,6 +7,8 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 - Provide entry points such as `MainMenu.tscn` and `LobbyMenu.tscn`.
 - Host the main gameplay tree in `Main.tscn` with `GameManager` as a `Node2D` root so terrain and board visuals appear.
 - Include UI fragments like `BoardUI.tscn`, `HandUI.tscn` and shop dialogs.
+- `StatsUI` sits at the top of the canvas, `BoardUI` fills the center and
+  `HandUI` anchors to the bottom so gameplay information is clearly separated.
 - Supply tutorial overlays that appear during the first run.
 
 ## Flow

--- a/scenes/StatsUI.tscn
+++ b/scenes/StatsUI.tscn
@@ -5,6 +5,7 @@
 [node name="StatsUI" type="HBoxContainer"]
 anchors_preset = -1
 anchor_right = 1.0
+anchor_bottom = 0.1
 script = ExtResource("1")
 
 [node name="Life" type="Label" parent="."]

--- a/ui/README.md
+++ b/ui/README.md
@@ -12,6 +12,11 @@ User interface scripts and scenes live here. They connect nodes to game managers
   sets `expand_icon` so large textures shrink to fit.
 - Present tutorial hints through `TutorialOverlay`.
 
+During play, the HUD divides the screen into three bands: `StatsUI` spans the
+top, `BoardUI` fills the middle, and `HandUI` anchors to the bottom. Each panel
+uses anchors instead of hard-coded coordinates so the layout scales with the
+window size.
+
 `HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.
 
 ## Public APIs


### PR DESCRIPTION
## Summary
- anchor StatsUI to top of screen
- anchor BoardUI to center area
- anchor HandUI at bottom
- explain layout in docs

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bc78d6148326ba474218f4c49724