### PR TITLE
Improve board updates

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 |------|-----------|----------------|
 | `battle_manager.gd` | `destroy(card)->void`, `unit_vs_unit(a,d)->void`, `full_attack(att,def)->void` | Resolve combat and remove dead units. |
 | `biome_shop.gd` | `buy(player, idx)->void` | Give a biome card to the player. |
-| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Maintain board grid and unit lists. |
+| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Maintain board grid and emit `board_changed` on updates. |
 | `card.gd` | `copy()->Card`, `damage(v)->void` | Duplicate card or apply damage. |
 | `card_database.gd` | `neutral()->Array`, `biome(b)->Array` | Provide card templates. |
 | `deck.gd` | `shuffle()->void`, `draw_n(n)->Array`, `add(card)->void` | Manage player deck ordering. |
@@ -26,7 +26,7 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 | `logger.gd` | `info(msg)->void`, `warn(msg)->void`, `error(msg)->void` | Simple logging facility. |
 | `market_manager.gd` | `open()->void`, `bid(player,amt)->void`, `close()->void` | Handle shop bidding rounds. |
 | `network_manager.gd` | `rpc_play_card(id,owner)->void`, `rpc_end_turn(owner)->void` | Forward network RPC to GameManager. |
-| `player.gd` | `draw(n)->void`, `start_turn()->void`, `end_turn()->void`, `opponent()->Player`, `summon_token(name,atk,hp)->void`, `consume_token(name,eff,val)->void`, `take_direct_dmg(v)->void` | Manage a player's resources and board presence. |
+| `player.gd` | `draw(n)->void`, `start_turn()->void`, `end_turn()->void`, `opponent()->Player`, `summon_token(name,atk,hp)->void`, `consume_token(name,eff,val)->void`, `take_direct_dmg(v)->void`, signal `board_changed(p)` | Manage a player's resources and board presence. |
 | `save_manager.gd` | `save_run(state)->void`, `load_run()->Dictionary` | Persist or load run state. |
 | `season_manager.gd` | `reset()->void`, `current()->String`, `advance_segment()->void` | Cycle through seasons and emit signals. |
 | `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void` | Spawn and update terrain tiles. |

--- a/scripts/board_manager.gd
+++ b/scripts/board_manager.gd
@@ -19,6 +19,7 @@ func init_board(players:Array) -> void:
 				col.append(null)
 			g.append(col)
 		grids[p] = g
+	EventBus.emit("board_changed")
 
 # -------------------------------------------------------------- placement
 func place_card(p, card:Card, x:int, y:int) -> bool:
@@ -31,6 +32,8 @@ func place_card(p, card:Card, x:int, y:int) -> bool:
 	else:
 		p.structures.append(card)
 	Logger.info("Placed %s at %d,%d" % [card.name, x, y])
+	p.emit_board()
+	EventBus.emit("board_changed")
 	return true
 
 # -------------------------------------------------------------- déplacement
@@ -44,6 +47,8 @@ func move_unit(p, from_x:int, from_y:int, to_x:int, to_y:int) -> bool:
 		return false
 	grids[p][from_x][from_y] = null
 	grids[p][to_x][to_y]     = c
+	p.emit_board()
+	EventBus.emit("board_changed")
 	return true
 
 # -------------------------------------------------------------- nettoyage
@@ -55,3 +60,5 @@ func remove_dead():
 				if c and c.hp <= 0:
 					grids[p][x][y] = null
 					Logger.info("%s destroyed at %d,%d" % [c.name, x, y])
+					c.owner.emit_board()
+					EventBus.emit("board_changed")

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -56,6 +56,7 @@ func _init_ui() -> void:
 
 			var board_ui := preload("res://scenes/BoardUI.tscn").instantiate()
 			board_ui.player_path = p.get_path()
+			board_ui.board_path  = board.get_path()
 			ui.add_child(board_ui)
 
 # ---------------------------------------------------------------- signaux

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,6 +5,7 @@ signal turn_end(p : Player)
 signal defeated(p : Player)
 signal hand_changed(p : Player)          # ← nouveau signal
 signal stats_changed(p : Player)
+signal board_changed(p : Player)
 
 @export var biome    : String = "Forest"
 @export var is_human : bool   = true
@@ -21,6 +22,9 @@ var tokens      : Dictionary  = {}
 
 func emit_stats() -> void:
 	emit_signal("stats_changed", self)
+
+func emit_board() -> void:
+	emit_signal("board_changed", self)
 
 func _ready() -> void:
 	add_child(deck)

--- a/ui/board_ui.gd
+++ b/ui/board_ui.gd
@@ -2,11 +2,19 @@ extends VBoxContainer
 class_name BoardUI
 
 @export var player_path : NodePath
+@export var board_path  : NodePath
 var player : Player
+var board  : BoardManager
 
 func _ready() -> void:
 	player = get_node(player_path)
+	board = get_node(board_path)
+	EventBus.connect("event", Callable(self, "_on_event"))
 	_refresh()
+
+func _on_event(tag:String, _payload:Dictionary) -> void:
+	if tag == "board_changed":
+		_refresh()
 
 # ----------------------------------------------------------------- refresh
 func _refresh() -> void:
@@ -14,15 +22,24 @@ func _refresh() -> void:
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
-
-	# 2) afficher les unités
-	for u in player.units:
-		var lbl := Label.new()
-		lbl.text = "%s  (%d/%d)" % [u.name, u.atk, u.hp]
-		add_child(lbl)
+	# 2) afficher la grille
+	if board and board.grids.has(player):
+		for y in board.height:
+			var row := HBoxContainer.new()
+			for x in board.width:
+				var lbl := Label.new()
+				var c : Card = board.grids[player][x][y]
+				lbl.text = c ? c.name : "-"
+				row.add_child(lbl)
+			add_child(row)
 
 	# 3) afficher les structures
-	for s in player.structures:
-		var lbl := Label.new()
-		lbl.text = "[S] %s  (%d PV)" % [s.name, s.hp]
-		add_child(lbl)
+	if player.structures.size() > 0:
+		var head := Label.new()
+		head.text = "Structures:"
+		add_child(head)
+		for s in player.structures:
+			var lbl := Label.new()
+			lbl.text = "[S] %s  (%d PV)" % [s.name, s.hp]
+			add_child(lbl)
+


### PR DESCRIPTION
## Summary
- refresh BoardUI when board state changes
- emit `board_changed` events from BoardManager
- expose `board_changed` signal from Player
- wire BoardUI to BoardManager via GameManager
- document new signal and event in scripts README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c29e01388326a3e86817d9d19c24