### PR TITLE
Improve board layout

### DIFF
--- a/scenes/README.md
+++ b/scenes/README.md
@@ -22,7 +22,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 | `LobbyMenu.tscn` | Connects peers and displays player list. |
 | `Main.tscn` | Contains battle board, managers and a background. |
 | `MarketDialog.tscn` | Popup for the neutral auction house. |
-| `TerrainTile.tscn` | Visual tile scene with drop shadow and a transparent `Control` overlay for hover detection. |
+| `TerrainTile.tscn` | Visual tile with drop shadow, a transparent `Control` overlay and a `Label` that shows the biome name. |
 
 
 Scenes rarely contain code beyond hooking up their child nodes. When adding a new scene, keep scripts minimal and delegate behaviour to a manager in `scripts/` or UI controller in `ui/` so the structure stays maintainable.

--- a/scenes/TerrainTile.tscn
+++ b/scenes/TerrainTile.tscn
@@ -17,4 +17,9 @@ texture = null
 [node name="Clickable" type="Control" parent="."]
 size = Vector2i(64, 64)
 
+[node name="Label" type="Label" parent="."]
+position = Vector2(0, -14)
+horizontal_alignment = 1
+text = ""
+
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,7 +30,7 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 | `save_manager.gd` | `save_run(state)->void`, `load_run()->Dictionary` | Persist or load run state. |
 | `season_manager.gd` | `reset()->void`, `current()->String`, `advance_segment()->void` | Cycle through seasons and emit signals. |
 | `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void` | Spawn and update terrain tiles. |
-| `terrain_tile.gd` | `set_biome(b)`, `apply_season(season)`, `set_color(color)`, `highlight(on)` | Uses a hidden `Control` child to detect hover; loads biome textures and tints tiles per season. |
+| `terrain_tile.gd` | `set_biome(b)`, `apply_season(season)`, `set_color(color)`, `highlight(on)` | Each tile now includes a `Label` showing its biome and still uses a hidden `Control` for hover detection. |
 | `tutorial_manager.gd` | `start()->void`, `on_action(tag)->void` | Drive tutorial step by step. |
 | `ai_pro.gd`, `ai_swarm.gd` | *(no public API)* | Internal AI routines. |
 

--- a/scripts/terrain_tile.gd
+++ b/scripts/terrain_tile.gd
@@ -17,6 +17,7 @@ var _base_color : Color = Color.WHITE
 @onready var sprite : Sprite2D = $Sprite2D
 @onready var shadow : Sprite2D = $Shadow
 @onready var clickable : Control = $Clickable
+@onready var lbl_biome : Label = $Label
 
 func _ready() -> void:
 	set_biome(biome)
@@ -24,11 +25,11 @@ func _ready() -> void:
 	clickable.mouse_exited.connect(Callable(self, "_on_mouse_exited"))
 
 	if sprite.texture == null:
-		var img := Image.create(64, 64, false, Image.FORMAT_RGBA8)
-		img.fill(Color.WHITE)
-		var tex := ImageTexture.create_from_image(img)
-		sprite.texture = tex
-		shadow.texture = tex
+	var img := Image.create(64, 64, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	var tex := ImageTexture.create_from_image(img)
+	sprite.texture = tex
+	shadow.texture = tex
 
 func apply_season(season:String) -> void:
 	if season_modifier.has(season):
@@ -42,7 +43,9 @@ func set_biome(b:String) -> void:
 		if tex:
 			sprite.texture = tex
 			shadow.texture = tex
-
+	if lbl_biome:
+		lbl_biome.text = biome
+	
 func set_color(color:Color) -> void:
 	_base_color = color
 	sprite.modulate = _base_color

--- a/ui/README.md
+++ b/ui/README.md
@@ -11,7 +11,8 @@ User interface scripts and scenes live here. They connect nodes to game managers
 - `CardButton` sizes icons based on the window (`size_ratio` export) and
   sets `expand_icon` so large textures shrink to fit.
 - Present tutorial hints through `TutorialOverlay`.
-- UI scripts keep tab indentation so Godot formatting stays uniform.
+- UI scripts keep tab indentation so Godot formatting stays uniform. `BoardUI`
+  now uses tabs exclusively after removing stray spaces.
 
 During play, the HUD divides the screen into three bands: `StatsUI` spans the
 top, `BoardUI` fills the middle, and `HandUI` anchors to the bottom. Each panel
@@ -19,8 +20,10 @@ uses anchors instead of hard-coded coordinates so the layout scales with the
 window size.
 
 `BoardUI` builds a `GridContainer` sized by `BoardManager.width` and
-`BoardManager.height`. Each cell shows the occupying card name or a dash when
-empty so players can track unit placement even before any cards are played.
+`BoardManager.height`. Each cell is a `Panel` with two centred labels: the
+occupying card name (or a dash when empty) and a second line for stats. Units
+display their `attack` and `hp` as "atk/hp" while structures show "HP: x". The
+panels expand to fill the available width so the board appears as a neat grid.
 
 `HandUI`, `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels, spawn buttons and react to button presses. They do not expose functions; instead they listen for signals like `hand_changed`, `stats_changed` or `auction_open` to refresh their content. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.
 

--- a/ui/board_ui.gd
+++ b/ui/board_ui.gd
@@ -27,13 +27,44 @@ func _refresh() -> void:
 	if board and board.grids.has(player):
 		var grid := GridContainer.new()
 		grid.columns = board.width
+		grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		grid.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		grid.custom_minimum_size = Vector2(0, 200)
 		for y in board.height:
 			for x in board.width:
-				var lbl := Label.new()
-				lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+				var cell := Panel.new()
+				cell.custom_minimum_size = Vector2(160, 80)
+				cell.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+				cell.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+				var box := VBoxContainer.new()
+				box.anchor_left = 0.0
+				box.anchor_top = 0.0
+				box.anchor_right = 1.0
+				box.anchor_bottom = 1.0
+
 				var c : Card = board.grids[player][x][y]
-				lbl.text = c.name if c else "-"
-				grid.add_child(lbl)
+
+				var lbl_name := Label.new()
+				lbl_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+				lbl_name.text = c.name if c else "-"
+				box.add_child(lbl_name)
+
+				var lbl_stats := Label.new()
+				lbl_stats.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+				if c:
+					if c.card_type == constants.CardType.UNIT:
+						lbl_stats.text = "%d/%d" % [c.atk, c.hp]
+					elif c.card_type == constants.CardType.STRUCTURE:
+						lbl_stats.text = "HP: %d" % c.hp
+					else:
+						lbl_stats.text = ""
+				else:
+					lbl_stats.text = ""
+				box.add_child(lbl_stats)
+
+				cell.add_child(box)
+				grid.add_child(cell)
 		add_child(grid)
 
 	# 3) afficher les structures


### PR DESCRIPTION
## Summary
- draw board cells as Panels so columns expand
- mention Panel-based grid layout in UI docs
- fix indentation in `board_ui.gd` and update docs about tabs
- add biome labels to terrain tiles

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f030642483269241de0fc3274635