### PR TITLE
Fix tab indentation across scripts

### DIFF
--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -1,0 +1,4 @@
+# Codex Guide
+
+When editing GDScript files always use **tab characters** for indentation. Godot
+expects tabs to align code properly.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,14 +9,14 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 - Provide AI behaviours and multiplayer RPCs through `NetworkManager`.
 - Offer small helpers such as `Logger` and `SaveManager`.
 - Spawn `BoardUI` and `HandUI` when a match starts.
-- All scripts use tabs for indentation; `terrain_manager.gd` was cleaned up to match.
+- All scripts use tab indentation; `board_manager.gd` and `terrain_manager.gd` were cleaned up to match.
 
 ## Public APIs
 | File | Functions | Effect on game |
 |------|-----------|----------------|
 | `battle_manager.gd` | `destroy(card)->void`, `unit_vs_unit(a,d)->void`, `full_attack(att,def)->void` | Resolve combat and remove dead units. |
 | `biome_shop.gd` | `buy(player, idx)->void` | Give a biome card to the player. |
-| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Maintain board grid and emit `board_changed` on updates. |
+| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Clear previous grids then rebuild and emit `board_changed` when slots update. |
 | `card.gd` | `copy()->Card`, `damage(v)->void` | Duplicate card or apply damage. |
 | `card_database.gd` | `neutral()->Array`, `biome(b)->Array` | Provide card templates. |
 | `deck.gd` | `shuffle()->void`, `draw_n(n)->Array`, `add(card)->void` | Manage player deck ordering. |
@@ -29,7 +29,7 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 | `player.gd` | `draw(n)->void`, `start_turn()->void`, `end_turn()->void`, `opponent()->Player`, `summon_token(name,atk,hp)->void`, `consume_token(name,eff,val)->void`, `take_direct_dmg(v)->void`, signal `board_changed(p)` | Manage a player's resources and board presence. |
 | `save_manager.gd` | `save_run(state)->void`, `load_run()->Dictionary` | Persist or load run state. |
 | `season_manager.gd` | `reset()->void`, `current()->String`, `advance_segment()->void` | Cycle through seasons and emit signals. |
-| `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void`, `groups_for_biome(b)->Array` | Spawn terrain tiles and expose groups per biome. |
+| `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void`, `groups_for_biome(b)->Array` | Recreate terrain visuals, removing old nodes, and expose groups per biome. |
 | `terrain_tile.gd` | `set_biome(b)`, `apply_season(season)`, `set_color(color)`, `highlight(on)` | Each tile now includes a `Label` showing its biome and still uses a hidden `Control` for hover detection. |
 | `tutorial_manager.gd` | `start()->void`, `on_action(tag)->void` | Drive tutorial step by step. |
 | `ai_pro.gd`, `ai_swarm.gd` | *(no public API)* | Internal AI routines. |

--- a/scripts/board_manager.gd
+++ b/scripts/board_manager.gd
@@ -3,7 +3,7 @@ class_name BoardManager
 
 var width  := 5
 var height := 3
-var grids  : Dictionary = {}                 # player -> 2-D array Card
+var grids  : Dictionary = {}				 # player -> 2-D array Card
 
 # -------------------------------------------------------------- helpers
 func _in_bounds(x:int, y:int) -> bool:
@@ -11,7 +11,8 @@ func _in_bounds(x:int, y:int) -> bool:
 
 # -------------------------------------------------------------- init
 func init_board(players:Array) -> void:
-	for p in players:
+	grids.clear()
+		for p in players:
 		var g : Array = []
 		for x in width:
 			var col : Array = []
@@ -46,7 +47,7 @@ func move_unit(p, from_x:int, from_y:int, to_x:int, to_y:int) -> bool:
 	if grids[p][to_x][to_y] != null:
 		return false
 	grids[p][from_x][from_y] = null
-	grids[p][to_x][to_y]     = c
+	grids[p][to_x][to_y]	 = c
 	p.emit_board()
 	EventBus.emit("board_changed")
 	return true

--- a/scripts/terrain_manager.gd
+++ b/scripts/terrain_manager.gd
@@ -12,6 +12,10 @@ var _visual_root : Node2D
 var _tile_scene : PackedScene = preload("res://scenes/TerrainTile.tscn")
 
 func init(players:Array) -> void:
+	if _visual_root:
+		remove_child(_visual_root)
+		_visual_root.queue_free()
+
 	_visual_root = Node2D.new()
 	add_child(_visual_root)
 


### PR DESCRIPTION
## Summary
- enforce tab indentation in `board_manager.gd`
- clean up `terrain_manager.gd` setup
- document tab style in `scripts/README.md`
- add `CODEX_GUIDE.md` noting tab requirement

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856048cd3248326abc617287eaf7c8b