### PR TITLE
Add card tooltips and board headers

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -9,8 +9,8 @@ User interface scripts and scenes live here. They connect nodes to game managers
 - Display resources such as life and gold (`StatsUI`) and provide an **End** button to finish the turn.
 - Provide menus for solo and network play (`MainMenu`, `LobbyMenu`).
 - Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
-- `CardButton` sizes icons based on the window (`size_ratio` export) and
-  sets `expand_icon` so large textures shrink to fit.
+- `CardButton` sizes icons based on the window (`size_ratio` export), sets
+  `expand_icon` and now displays a tooltip with cost, stats and effects.
 - Present tutorial hints through `TutorialOverlay`.
 - UI scripts keep tab indentation so Godot formatting stays uniform. `BoardUI`
   now uses tabs exclusively after removing stray spaces.
@@ -21,9 +21,10 @@ uses anchors instead of hard-coded coordinates so the layout scales with the
 window size.
 
 `BoardUI` builds a `GridContainer` sized by `BoardManager.width` and
-`BoardManager.height`. Each cell is a `Panel` with two centred labels: the
-occupying card name (or a dash when empty) and a second line for stats. Units
-display their `attack` and `hp` as "atk/hp" while structures show "HP: x". The
+`BoardManager.height`. A label with the player's name appears above the grid.
+Each cell is a `Panel` with two centred labels: the occupying card name (or a
+dash when empty) and a second line for stats. Units display their `attack` and
+`hp` as "atk/hp" while structures show "HP: x". The
 panels expand to fill the available width so the board appears as a neat grid.
 
 `HandUI` connects each `CardButton` to `GameManager.play_card` when dragged so cards are played instantly. `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels or buttons when notified via signals like `hand_changed`, `stats_changed` or `auction_open`. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.

--- a/ui/board_ui.gd
+++ b/ui/board_ui.gd
@@ -18,12 +18,18 @@ func _on_event(tag:String, _payload:Dictionary) -> void:
 
 # ----------------------------------------------------------------- refresh
 func _refresh() -> void:
-	# 1) nettoyer le container
-	for child in get_children():
-		remove_child(child)
-		child.queue_free()
+        # 1) nettoyer le container
+        for child in get_children():
+                remove_child(child)
+                child.queue_free()
 
-	# 2) grille de jeu
+        # Nom du joueur
+        var head := Label.new()
+        head.text = player.name
+        head.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+        add_child(head)
+
+        # 2) grille de jeu
 	if board and board.grids.has(player):
 		var grid := GridContainer.new()
 		grid.columns = board.width
@@ -68,10 +74,10 @@ func _refresh() -> void:
 		add_child(grid)
 
 	# 3) afficher les structures
-	if player.structures.size() > 0:
-		var head := Label.new()
-		head.text = "Structures:"
-		add_child(head)
+        if player.structures.size() > 0:
+                var head_struct := Label.new()
+                head_struct.text = "Structures:"
+                add_child(head_struct)
 		for s in player.structures:
 			var lbl := Label.new()
 			lbl.text = "[S] %s  (%d PV)" % [s.name, s.hp]

--- a/ui/card_button.gd
+++ b/ui/card_button.gd
@@ -22,12 +22,35 @@ const CARD_TEXTURES := {
 signal dragged(card : Card)
 
 func _ready() -> void:
-		text = card_data.name
-		icon = CARD_TEXTURES.get(card_data.biome, CARD_TEXTURES["Neutral"])
-		expand_icon = true
-		var width := get_viewport_rect().size.x * size_ratio
-		custom_minimum_size = Vector2(width, width * 1.5)
+                text = card_data.name
+                icon = CARD_TEXTURES.get(card_data.biome, CARD_TEXTURES["Neutral"])
+                expand_icon = true
+                var width := get_viewport_rect().size.x * size_ratio
+                custom_minimum_size = Vector2(width, width * 1.5)
+
+                # tooltip avec coût et statistiques
+                var cost := 3
+                match card_data.card_type:
+                        constants.CardType.UNIT: cost = 2
+                        constants.CardType.SPELL: cost = 1
+
+                var stat_text := ""
+                if card_data.card_type == constants.CardType.UNIT:
+                        stat_text = "%d/%d" % [card_data.atk, card_data.hp]
+                elif card_data.card_type == constants.CardType.STRUCTURE:
+                        stat_text = "HP: %d" % card_data.hp
+
+                var effect_str := ""
+                for key in card_data.effects.keys():
+                        effect_str += "%s: %s\n" % [key, card_data.effects[key].to_string()]
+
+                tooltip_text = "Coût: %d\nStats: %s\n%s" % [cost, stat_text, effect_str]
+
+                pressed.connect(_on_pressed)
 
 func _gui_input(event : InputEvent) -> void:
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		emit_signal("dragged", card_data)
+        if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+                emit_signal("dragged", card_data)
+
+func _on_pressed() -> void:
+        emit_signal("dragged", card_data)


### PR DESCRIPTION
## Summary
- show player name above each board grid
- display a tooltip on CardButton with cost, stats and effects
- allow playing cards via button press
- update UI README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a46659e483268930d727ceb93d59