### PR TITLE
Improve basic gameplay flow

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ This folder collects all gameplay logic. Each GDScript stays loaded so managers 
 - Offer small helpers such as `Logger` and `SaveManager`.
 - Spawn `BoardUI` for every player but only create `StatsUI` and `HandUI` for human participants so AI hands never overlap in the HUD.
 - All scripts use tab indentation; `board_manager.gd` and `terrain_manager.gd` were cleaned up to match.
+- `GameManager.play_card` now emits `hand_changed` so the UI refreshes instantly and calls `BoardManager.remove_dead` after resolving effects.
 
 ## Public APIs
 | File | Functions | Effect on game |

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -23,6 +23,7 @@ func play_card(card:Card, p:Player) -> void:
 	p.mana -= cost
 	p.emit_stats()
 	p.hand.erase(card)
+	p.emit_signal("hand_changed", p)
 
 	if card.card_type == constants.CardType.SPELL:
 		var eff : Dictionary = card.effects.get(SeasonManager.current(), {})
@@ -34,6 +35,7 @@ func play_card(card:Card, p:Player) -> void:
 		var pos := _find_slot(p)
 		if pos:
 			board.place_card(p, card, pos.x, pos.y)
+			board.remove_dead()
 	EventBus.emit("card_played")
 
 func _find_slot(p:Player) -> Vector2i:
@@ -104,6 +106,7 @@ func _connect_signals() -> void:
 # ---------------------------------------------------------------- callbacks
 func _on_turn_end(p : Player) -> void:
 	BattleManager.full_attack(p, p.opponent())
+	board.remove_dead()
 
 	turn_idx = (turn_idx + 1) % players.size()
 	if turn_idx == 0:
@@ -119,6 +122,7 @@ func _season_tick(_season:int) -> void:
 			if u.status.burn   > 0: u.damage(u.status.burn)
 			if u.status.poison > 0: u.damage(u.status.poison)
 			if u.status.frozen > 0: u.status.frozen = 0
+	board.remove_dead()
 
 func _on_season_start(_season:int) -> void:
 	terrain.season_update(SeasonManager.current())


### PR DESCRIPTION
## Summary
- update game manager to refresh hand after playing cards
- clean up dead units after combat and effects
- mention the new behavior in scripts README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6856ac8f0e648326ad4e96f73bc1068a