### PR TITLE
Add BoardsPanel and multi-board layout

### DIFF
--- a/scenes/BoardUI.tscn
+++ b/scenes/BoardUI.tscn
@@ -4,7 +4,7 @@
 
 [node name="BoardUI" type="VBoxContainer"]
 anchors_preset = -1
-anchor_right = 0.75
-anchor_top = 0.1
-anchor_bottom = 0.8
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 1.0
 script = ExtResource("1")

--- a/scenes/BoardsPanel.tscn
+++ b/scenes/BoardsPanel.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=1 format=3]
+
+[node name="BoardsPanel" type="HBoxContainer"]
+anchors_preset = -1
+anchor_right = 0.75
+anchor_top = 0.1
+anchor_bottom = 0.8

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -6,8 +6,8 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 ## Responsibilities
 - Provide entry points such as `MainMenu.tscn` and `LobbyMenu.tscn`.
 - Host the main gameplay tree in `Main.tscn` with `GameManager` as a `Node2D` root so terrain and board visuals appear.
-- Include UI fragments like `BoardUI.tscn`, `HandUI.tscn` and shop dialogs.
- - `StatsUI` sits at the top of the canvas with an **End** button, `BoardUI` fills the center and
+- Include UI fragments like `BoardsPanel.tscn`, `BoardUI.tscn`, `HandUI.tscn` and shop dialogs.
+ - `StatsUI` sits at the top of the canvas with an **End** button, `BoardsPanel` holds multiple `BoardUI` instances in the center and
    `HandUI` anchors to the bottom so gameplay information is clearly separated.
  - `TutorialOverlay.tscn` shows hints when running the tutorial.
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -81,6 +81,8 @@ func _spawn_players() -> void:
 
 func _init_ui() -> void:
 	var ui := $UI
+	var boards_panel := preload("res://scenes/BoardsPanel.tscn").instantiate()
+	ui.add_child(boards_panel)
 	for p in players:
 		if p.is_human:
 			var stats := preload("res://scenes/StatsUI.tscn").instantiate()
@@ -94,7 +96,8 @@ func _init_ui() -> void:
 		var board_ui := preload("res://scenes/BoardUI.tscn").instantiate()
 		board_ui.player_path = p.get_path()
 		board_ui.board_path  = board.get_path()
-		ui.add_child(board_ui)
+		board_ui.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		boards_panel.add_child(board_ui)
 
 	var history := preload("res://scenes/HistoryUI.tscn").instantiate()
 	ui.add_child(history)

--- a/ui/README.md
+++ b/ui/README.md
@@ -19,10 +19,10 @@ User interface scripts and scenes live here. They connect nodes to game managers
   now uses tabs exclusively after removing stray spaces.
 
 During play, the HUD divides the screen into three bands: `StatsUI` spans the
-top, `BoardUI` fills the middle, and `HandUI` anchors to the bottom. Each panel
-uses anchors instead of hard-coded coordinates so the layout scales with the
-HistoryUI occupies the right quarter of the screen and lists recent events.
-window size.
+top, `BoardsPanel` fills the middle and holds one `BoardUI` per player, and
+`HandUI` anchors to the bottom. Each panel uses anchors instead of hard-coded
+coordinates so the layout scales with the window size. `HistoryUI` occupies the
+right quarter of the screen and lists recent events.
 
 `BoardUI` builds a `GridContainer` sized by `BoardManager.width` and
 `BoardManager.height`. A label with the player's name appears above the grid.


### PR DESCRIPTION
## Summary
- update BoardUI scene anchors
- introduce BoardsPanel container to host multiple boards
- lay out board UIs via BoardsPanel in GameManager
- document BoardsPanel in UI and Scenes READMEs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d46e417c83268ae575606f93d606