### PR TITLE
Show other player resources on board

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -18,7 +18,8 @@ User interface scripts and scenes live here. They connect nodes to game managers
 - UI scripts keep tab indentation so Godot formatting stays uniform. `BoardUI`
   now uses tabs exclusively after removing stray spaces.
 - `BoardUI` listens to both the global `board_changed` event and each player's
-  own `board_changed` signal so opponent boards refresh immediately.
+  own `board_changed` signal so opponent boards refresh immediately. It also
+  shows the life, gold, essence and mana of every player below their name.
 
 During play, the HUD divides the screen into three bands: `StatsUI` spans the
 top, `BoardsPanel` fills the middle and holds one `BoardUI` per player, and
@@ -27,7 +28,8 @@ coordinates so the layout scales with the window size. `HistoryUI` occupies the
 right quarter of the screen and lists recent events.
 
 `BoardUI` builds a `GridContainer` sized by `BoardManager.width` and
-`BoardManager.height`. A label with the player's name appears above the grid.
+`BoardManager.height`. A label with the player's name appears above the grid
+followed by a row showing their resources.
 Each cell is a `Panel` with the card name followed by three lines: stats,
 mana cost and a short list of effect names. Units display their `attack` and
 `hp` as "atk/hp" while structures show "HP: x". The panels expand to fill

--- a/ui/board_ui.gd
+++ b/ui/board_ui.gd
@@ -11,7 +11,8 @@ func _ready() -> void:
 	board = get_node(board_path)
 	EventBus.connect("event", Callable(self, "_on_event"))
 	if player:
-		player.connect("board_changed", Callable(self, "_refresh"))
+	player.connect("board_changed", Callable(self, "_refresh"))
+	player.connect("stats_changed", Callable(self, "_refresh"))
 	_refresh()
 
 func _on_event(tag:String, _payload:Dictionary) -> void:
@@ -30,6 +31,22 @@ func _refresh() -> void:
 	head.text = player.name
 	head.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	add_child(head)
+
+	# Statistiques du joueur
+	var stats := HBoxContainer.new()
+	var lbl_life := Label.new()
+	lbl_life.text = "Life: %d" % player.life
+	stats.add_child(lbl_life)
+	var lbl_gold := Label.new()
+	lbl_gold.text = "Gold: %d" % player.gold
+	stats.add_child(lbl_gold)
+	var lbl_ess := Label.new()
+	lbl_ess.text = "Essence: %d" % player.essence
+	stats.add_child(lbl_ess)
+	var lbl_mana := Label.new()
+	lbl_mana.text = "Mana: %d" % player.mana
+	stats.add_child(lbl_mana)
+	add_child(stats)
 
 	# 2) grille de jeu
 	if board and board.grids.has(player):


### PR DESCRIPTION
## Summary
- display each player's life, gold, essence and mana directly in BoardUI
- refresh opponent board UI when their stats change
- document the new behaviour in `ui/README.md`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dcae9f088326957556aec183997a