### PR TITLE
Add docs architecture and ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,9 @@ High level design material lives here so new contributors can quickly understand
 - Record Architectural Decision Records (ADRs) for major changes.
 
 ## Structure
-- `architecture.md` explains how managers interact and includes diagrams. Update it when adding or refactoring systems.
-- `glossary.md` lists short definitions of important game terminology.
-- `adr/` holds numbered ADR files that justify design choices such as chosen network protocol or UI toolkit.
+- `architecture.md` outlines how managers and scenes connect and includes small diagrams. Update it whenever systems change.
+- `glossary.md` offers brief definitions of important game terms so discussions stay consistent.
+- `adr/` stores numbered decision records, beginning with `0001-networking-choice.md` which documents the ENet stack.
 
 Each document should be concise so the folder remains readable. When implementing a new feature, check if any diagrams need updates and add an ADR entry if the change alters the project's direction.
 

--- a/docs/adr/0001-networking-choice.md
+++ b/docs/adr/0001-networking-choice.md
@@ -1,0 +1,13 @@
+# 0001 Networking Choice
+
+## Status
+Accepted
+
+## Context
+Multiplayer matches need reliable delivery without excessive overhead. Godot ships with ENet support, which offers ordered, reliable UDP and works out of the box across desktop platforms.
+
+## Decision
+Use Godot's ENet API for the lobby and in-game RPCs. It keeps latency low and simplifies hosting, avoiding extra dependencies.
+
+## Consequences
+Peers must connect directly or via port forwarding. Web builds cannot join because they require WebRTC, but native clients remain lightweight and cross-platform.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+
+This project uses a set of Godot singletons to coordinate gameplay. `GameManager` sits at the center and drives turns, drawing from `Deck` objects and applying effects through `EffectProcessor`. It invokes `BattleManager` when units clash and notifies `BoardManager` so the board refreshes.
+
+`SeasonManager` and `TerrainManager` work together to change the biome each turn. They rebuild tiles and adjust visuals so that cards react to the environment. The `MarketManager` and `BiomeShop` open temporary dialogs allowing players to spend gold between battles. When the auction closes they send results back through `EventBus` signals.
+
+`NetworkManager` mirrors actions to connected peers using reliable UDP (ENet). Every UI script listens for changes via signals: `BoardUI` tracks the grid, `StatsUI` shows resources and `HandUI` handles drag-and-drop. These panels live under scenes described in `scenes/README.md`.
+
+Saving and loading runs happens through `SaveManager`. Small utilities like `Logger` keep output consistent across the command line and editor. The architecture keeps scenes lightweight so most logic lives in scripts, making new features easier to test.
+
+The diagram below shows the high level flow:
+
+```
+Main.tscn -> GameManager -> {BoardManager, SeasonManager, BattleManager}
+                                 ↳ NetworkManager ↔ peers
+                                 ↳ MarketManager ↔ UI dialogs
+```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,23 @@
+# Glossary
+
+**Biome** – The environment theme for a match segment. Seasons modify the active biome, changing card bonuses and terrain visuals.
+
+**Board** – The grid of tiles where cards are placed. Each player has their own board with units and structures.
+
+**Deck** – A shuffled stack of cards drawn each turn. Cards come from neutral structures or biome packs.
+
+**Effect** – A dictionary describing damage, buffs or resource changes processed by `EffectProcessor`.
+
+**Essence** – A resource earned while playing cards; certain abilities spend essence instead of mana.
+
+**Hand** – The set of cards drawn from the deck and displayed with `HandUI`.
+
+**Lobby** – The waiting room for network play. `NetworkManager` synchronises players before the match begins.
+
+**Mana** – Points spent to play most cards. Regenerates at the start of a player's turn.
+
+**Season** – Part of the game calendar. Seasons determine which biome is active and may alter card stats.
+
+**Structure** – A permanent card type that remains on the board until destroyed. Unlike units, structures do not attack.
+
+**Unit** – A creature card with attack and health stats. Units can move and fight on the board.


### PR DESCRIPTION
## Summary
- document architecture and key terms
- add ADR folder with initial networking choice
- update docs/README to point to new documents

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e36706108326b7bf9a9b5789f762