### PR TITLE
Update UI and scripts README sizes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,38 +1,28 @@
 # Scripts
 
 ## Why
-This folder collects all gameplay logic. Each GDScript stays loaded so managers can coordinate turns, AI and networking across scenes.
+Gameplay logic and autoloaded singletons live here. Keeping them together lets managers coordinate turns, AI and networking across scenes.
 
 ## Responsibilities
-- Orchestrate players and seasons via `GameManager`, `SeasonManager` and `BattleManager`.
-- Handle card data, decks and in-game effects.
-- Provide AI behaviours and multiplayer RPCs through `NetworkManager`.
-- Offer small helpers such as `Logger` and `SaveManager`.
-- Spawn `BoardUI` for every player but only create `StatsUI` and `HandUI` for human participants so AI hands never overlap in the HUD.
-- All scripts use tab indentation; `board_manager.gd` and `terrain_manager.gd` were cleaned up to match.
-- `GameManager.play_card` now emits `hand_changed` so the UI refreshes instantly and calls `BoardManager.remove_dead` after resolving effects.
-- AI routines call `GameManager.play_card` directly so structures appear on every board without extra triggers.
+- Control turns and seasons via `GameManager`, `SeasonManager` and `BattleManager`.
+- Manage card data, decks and board state.
+- Provide AI routines and network RPCs through `NetworkManager`.
+- Offer helpers like `Logger`, `SaveManager` and `EventBus`.
+- Manage terrain visuals each season through `TerrainManager` and `TerrainTile`.
 
-## Public APIs
-| File | Functions | Effect on game |
-|------|-----------|----------------|
-| `battle_manager.gd` | `destroy(card)->void`, `unit_vs_unit(a,d)->void`, `full_attack(att,def)->void` | Resolve combat and remove dead units. |
-| `biome_shop.gd` | `buy(player, idx)->void` | Give a biome card to the player. |
-| `board_manager.gd` | `init_board(players)->void`, `place_card(p,card,x,y)->bool`, `move_unit(p,x1,y1,x2,y2)->bool`, `remove_dead()->void` | Clear previous grids then rebuild and emit `board_changed` when slots update. |
-| `card.gd` | `copy()->Card`, `damage(v)->void` | Duplicate card or apply damage. |
-| `card_database.gd` | `neutral()->Array`, `biome(b)->Array` | Provide card templates. |
-| `deck.gd` | `shuffle()->void`, `draw_n(n)->Array`, `add(card)->void` | Manage player deck ordering. |
-| `effect_processor.gd` | `apply(effect, src, tgt)->void` | Execute card effect dictionaries. |
-| `event_bus.gd` | `emit(tag, payload={})->void` | Broadcast global events. |
-| `game_manager.gd` | `play_card(card,p)->void`, `remote_play_card(id,owner)->void`, `remote_end_turn(owner)->void` | Handle card use locally and for network peers. |
-| `logger.gd` | `info(msg)->void`, `warn(msg)->void`, `error(msg)->void` | Simple logging facility. |
-| `market_manager.gd` | `open()->void`, `bid(player,amt)->void`, `close()->void` | Handle shop bidding rounds. |
-| `network_manager.gd` | `rpc_play_card(id,owner)->void`, `rpc_end_turn(owner)->void` | Forward network RPC to GameManager. |
-| `player.gd` | `draw(n)->void`, `start_turn()->void`, `end_turn()->void`, `opponent()->Player`, `summon_token(name,atk,hp)->void`, `consume_token(name,eff,val)->void`, `take_direct_dmg(v)->void`, signal `board_changed(p)` | Manage a player's resources and board presence. |
-| `save_manager.gd` | `save_run(state)->void`, `load_run()->Dictionary` | Persist or load run state. |
-| `season_manager.gd` | `reset()->void`, `current()->String`, `advance_segment()->void` | Cycle through seasons and emit signals. |
-| `terrain_manager.gd` | `init(players)->void`, `season_update(season)->void`, `groups_for_biome(b)->Array` | Recreate terrain visuals, removing old nodes, and expose groups per biome. |
-| `terrain_tile.gd` | `set_biome(b)`, `apply_season(season)`, `set_color(color)`, `highlight(on)` | Each tile now includes a `Label` showing its biome and still uses a hidden `Control` for hover detection. |
-| `tutorial_manager.gd` | `start()->void`, `on_action(tag)->void` | Drive tutorial step by step. |
-| `ai_pro.gd`, `ai_swarm.gd` | *(no public API)* | Internal AI routines. |
+`GameManager.play_card` emits `hand_changed` so the UI refreshes and calls `BoardManager.remove_dead` after resolving effects. AI opponents call the same method so structures spawn without extra triggers. `BoardManager` rebuilds the grid and emits `board_changed` whenever units move. Tutorial steps use `TutorialManager.start()` and `on_action(tag)`.
 
+## Key APIs
+| Script | Functions |
+|--------|-----------|
+| `battle_manager.gd` | `destroy(card)`, `unit_vs_unit(a,d)`, `full_attack(att,def)` |
+| `board_manager.gd` | `init_board(players)`, `place_card(p,card,x,y)`, `move_unit(...)`, `remove_dead()` |
+| `game_manager.gd` | `play_card(card,p)`, `remote_play_card(id,owner)`, `remote_end_turn(owner)` |
+| `network_manager.gd` | `rpc_play_card(id,owner)`, `rpc_end_turn(owner)` |
+| `player.gd` | `draw(n)`, `start_turn()`, `end_turn()`, signal `board_changed(p)` |
+| `season_manager.gd` | `reset()`, `current()`, `advance_segment()` |
+| `effect_processor.gd` | `apply(effect, src, tgt)` |
+| Helpers | `Logger.info(msg)`, `SaveManager.save_run(state)` |
+
+Example: when a player uses a card, `GameManager.play_card` updates the board then `NetworkManager` forwards the RPC so peers stay in sync.
+Market auctions rely on `MarketManager` which opens, bids and closes each round.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,53 +1,24 @@
 # UI
 
 ## Why
-User interface scripts and scenes live here. They connect nodes to game managers via signals so that the board, shop and menus always reflect current gameplay.
+UI scripts and scenes live here. They connect menu buttons and HUD nodes to game managers so the display always matches current gameplay.
 
 ## Responsibilities
-- Render a player's hand, battlefield and shops (`HandUI`, `BoardUI`, `BiomeShopUI`) and the action log (`HistoryUI`).
-- `HandUI` and `StatsUI` are only instantiated for human players so AI opponents never create overlapping HUD elements.
-- Display resources such as life and gold (`StatsUI`) and provide an **End** button to finish the turn.
-- Provide menus for solo and network play (`MainMenu`, `LobbyMenu`).
-- Support drag and drop of cards and show dialogs (`CardButton`, `MarketDialog`).
-- `CardButton` sizes icons based on the window (`size_ratio` export) and
-  uses its built‑in `icon` property to display the card artwork. A
-  `VBoxContainer` inside the button stacks four labels beneath the icon:
-  name, stats, mana cost and effect names. Hovering reveals the same
-  details in a tooltip.
-- Present tutorial hints through `TutorialOverlay`.
-- UI scripts keep tab indentation so Godot formatting stays uniform. `BoardUI`
-  now uses tabs exclusively after removing stray spaces.
-- `BoardUI` listens to both the global `board_changed` event and each player's
-  own `board_changed` signal so opponent boards refresh immediately. It also
-  shows the life, gold, essence and mana of every player below their name.
+- Render hands, boards, shops and the action log.
+- Provide `MainMenu` and `LobbyMenu` for solo or online play.
+- Show resources and the end-turn button through `StatsUI`.
+- Support drag and drop via `CardButton` and open dialogs such as `MarketDialog`.
+- Spawn `HandUI` and `StatsUI` only for human players to avoid AI HUD clutter.
+- Offer tutorial hints through `TutorialOverlay`.
+- Use anchored containers so layouts scale with window size.
 
-During play, the HUD divides the screen into three bands: `StatsUI` spans the
-top, `BoardsPanel` fills the middle and holds one `BoardUI` per player, and
-`HandUI` anchors to the bottom. Each panel uses anchors instead of hard-coded
-coordinates so the layout scales with the window size. `HistoryUI` occupies the
-right quarter of the screen and lists recent events.
-
-`BoardUI` builds a `GridContainer` sized by `BoardManager.width` and
-`BoardManager.height`. A label with the player's name appears above the grid
-followed by a row showing their resources.
-Each cell is a `Panel` with the card name followed by three lines: stats,
-mana cost and a short list of effect names. Units display their `attack` and
-`hp` as "atk/hp" while structures show "HP: x". The panels expand to fill
-the available width so the board appears as a neat grid.
-
-`HandUI` shows the same details for each card by using `CardButton`, so the
-player always sees stats, cost and effects while choosing a card to play.
-
-`HandUI` connects each `CardButton` to `GameManager.play_card` when dragged so cards are played instantly. `BoardUI`, `StatsUI`, `BiomeShopUI` and `MarketDialog` update text labels or buttons when notified via signals like `hand_changed`, `stats_changed` or `auction_open`. `LobbyMenu` manages the network lobby by connecting to `NetworkManager` signals. `MainMenu` transitions to the lobby or tutorial scenes and keeps the window in a 1280×720 launcher mode. When a game starts, both menus switch the display to exclusive fullscreen at 1920×1080.
+`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent.
 
 ## Public APIs
-Only `TutorialOverlay` exposes calls so other nodes can show or hide tips when needed.
+| File | Functions | Effect |
+|------|-----------|-------|
+| `tutorial_overlay.gd` | `show_tip(msg)`, `hide()` | Toggle tutorial popups. |
+| `card_button.gd` | signal `dragged(card)` | Emits when dragging a card icon. |
+| Other scripts | *(none)* | Listen for events and refresh the HUD. |
 
-| File | Functions | Effect on game |
-|------|-----------|----------------|
-| `tutorial_overlay.gd` | `show_tip(msg)`, `hide()` | Display or remove an instructional popup. |
-| `card_button.gd` | signal `dragged(card)` | Sends the card when the player drags its icon. |
-| Other UI scripts | *(no public functions)* | They update visuals when notified via signals. |
-
-
-Even without direct APIs, these scripts form the backbone of the player's experience. Any future additions to the HUD or dialogs should follow the same pattern: emit a signal from gameplay code, listen here, and update nodes in `ready` or signal callbacks.
+When a card is dragged, `HandUI` forwards the signal to `GameManager.play_card`. Menus run at 1280×720 in windowed mode, then switch to fullscreen at 1920×1080 when a match begins. Full layout notes live in `details.md`.

--- a/ui/details.md
+++ b/ui/details.md
@@ -1,0 +1,10 @@
+# UI Details
+
+This document holds the extended layout notes that were trimmed from `README.md`.
+
+### Layout
+During play the HUD divides the screen into three bands: `StatsUI` at the top, `BoardsPanel` with one `BoardUI` per player in the middle, and `HandUI` anchored at the bottom. `HistoryUI` occupies the right quarter. Anchors replace hard-coded positions so everything scales with the window.
+
+`BoardUI` builds a grid based on `BoardManager.width` and `height`. A label above the grid shows the player's name followed by life, gold, essence and mana. Each cell is a `Panel` listing the card name, stats and cost. Units display attack and hit points as "atk/hp" while structures show "HP: x".
+
+`HandUI` relies on the same `CardButton` layout. Dragging a card connects to `GameManager.play_card`. Shops and dialogs update through signals such as `hand_changed`, `stats_changed` and `auction_open`. Menus start in a 1280×720 window and switch to 1920×1080 fullscreen when a match begins.


### PR DESCRIPTION
## Summary
- shorten `ui/README.md`
- move layout notes to `ui/details.md`
- trim `scripts/README.md`

## Testing
- `wc ui/README.md`
- `wc scripts/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6856e6c0911c83269affbee9d07cdb1f