### PR TITLE
Implement biome shop dialog flow

### DIFF
--- a/scenes/README.md
+++ b/scenes/README.md
@@ -13,7 +13,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 
 ## Flow
 
-`MainMenu.tscn` loads first and lets the player choose solo, network or tutorial. Menus display in a 1280×720 window so the game launches in a compact mode. In multiplayer the `LobbyMenu.tscn` waits until enough peers join before moving to `Main.tscn`. When a match begins, the window switches to exclusive fullscreen at 1920×1080. During play the board and terrain are spawned under `GameManager`. Dialogs for the market and biome shop are instantiated only when opened, keeping the scene tree lean.
+`MainMenu.tscn` loads first and lets the player choose solo, network or tutorial. Menus display in a 1280×720 window so the game launches in a compact mode. In multiplayer the `LobbyMenu.tscn` waits until enough peers join before moving to `Main.tscn`. When a match begins, the window switches to exclusive fullscreen at 1920×1080. During play the board and terrain are spawned under `GameManager`. Dialogs for the market and biome shop are instantiated only when opened, keeping the scene tree lean. `GameManager` spawns `BiomeShopDialog` at every season start so players can purchase biome cards before the first turn.
 
 ## Key Scenes
 | Scene | Purpose |
@@ -23,6 +23,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 | `Main.tscn` | Contains battle board, managers and a background. |
 | `HistoryUI.tscn` | Panel showing the action log on the right side. |
 | `MarketDialog.tscn` | Popup for the neutral auction house. |
+| `BiomeShopDialog.tscn` | Popup showing seasonal cards at the start of each season. |
 | `TerrainTile.tscn` | Visual tile with drop shadow, a transparent `Control` overlay and a `Label` that shows the biome name. |
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - Provide AI routines and network RPCs through `NetworkManager`.
 - Offer helpers like `Logger`, `SaveManager` and `EventBus`.
 - Manage terrain visuals each season through `TerrainManager` and `TerrainTile`.
+- Spawn a `BiomeShop` at every season start so players can buy biome cards.
 
 `GameManager.play_card` emits `hand_changed` so the UI refreshes and calls `BoardManager.remove_dead` after resolving effects. AI opponents call the same method so structures spawn without extra triggers. `BoardManager` rebuilds the grid and emits `board_changed` whenever units move. Tutorial steps use `TutorialManager.start()` and `on_action(tag)`.
 
@@ -26,3 +27,5 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 
 Example: when a player uses a card, `GameManager.play_card` updates the board then `NetworkManager` forwards the RPC so peers stay in sync.
 Market auctions rely on `MarketManager` which opens, bids and closes each round.
+`_on_season_start` instantiates `BiomeShopDialog` with the new shop, then closes
+it once a card is purchased and refills the stock.

--- a/scripts/biome_shop.gd
+++ b/scripts/biome_shop.gd
@@ -9,9 +9,9 @@ var stock : Array[Card] = []
 func _ready(): _refill()
 
 func _refill():
-	var pool := CardDatabase.biome(biome).duplicate()
-	pool.shuffle()
-	stock = pool.slice(0, size)
+        var pool : Array[Card] = CardDatabase.biome(biome).duplicate() as Array[Card]
+        pool.shuffle()
+        stock = pool.slice(0, size)
 
 func buy(p:Player, idx:int):
 	if p.gold < 4 or p.essence < 2: return

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -133,7 +133,21 @@ func _season_tick(_season:int) -> void:
 	board.remove_dead()
 
 func _on_season_start(_season:int) -> void:
-	terrain.season_update(SeasonManager.current())
+        terrain.season_update(SeasonManager.current())
+
+        var shop := BiomeShop.new()
+        shop.biome = SeasonManager.current()
+        add_child(shop)
+
+        var dialog : BiomeShopUI = preload("res://scenes/BiomeShopDialog.tscn").instantiate()
+        dialog.shop_path = shop.get_path()
+        $UI.add_child(dialog)
+        shop.connect("bought", Callable(self, "_on_shop_bought").bind(dialog, shop))
+        dialog.popup_centered()
+
+func _on_shop_bought(_p:Player, _c:Card, dialog:BiomeShopUI, shop:BiomeShop) -> void:
+        dialog.hide()
+        shop._refill()
 
 func _on_defeat(p : Player) -> void:
 	Logger.info("%s lost – Game Over" % p.name)

--- a/ui/README.md
+++ b/ui/README.md
@@ -8,11 +8,12 @@ UI scripts and scenes live here. They connect menu buttons and HUD nodes to game
 - Provide `MainMenu` and `LobbyMenu` for solo or online play.
 - Show resources and the end-turn button through `StatsUI`.
 - Support drag and drop via `CardButton` and open dialogs such as `MarketDialog`.
+- `BiomeShopUI` lists seasonal cards and hooks to `BiomeShop`.
 - Spawn `HandUI` and `StatsUI` only for human players to avoid AI HUD clutter.
 - Offer tutorial hints through `TutorialOverlay`.
 - Use anchored containers so layouts scale with window size.
 
-`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent.
+`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season.
 
 ## Public APIs
 | File | Functions | Effect |


### PR DESCRIPTION
## Summary
- open the biome shop at each season start via `GameManager`
- hook `BiomeShopUI` to the correct `BiomeShop` node and close the popup when buying
- document the season shop flow in READMEs
- fix typed array assignment in `BiomeShop`

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e97e959c83269cb5d4785c9702e3