### PR TITLE
Implement board movement

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -14,6 +14,7 @@ UI scripts and scenes live here. They connect menu buttons and HUD nodes to game
 - Use anchored containers so layouts scale with window size.
 
 `StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season.
+Players can click a unit then select a destination tile to move it. Dragging works too, forwarding the coordinates to `BoardManager.move_unit`.
 
 ## Public APIs
 | File | Functions | Effect |

--- a/ui/board_ui.gd
+++ b/ui/board_ui.gd
@@ -5,6 +5,7 @@ class_name BoardUI
 @export var board_path  : NodePath
 var player : Player
 var board  : BoardManager
+var selected_from := Vector2i(-1, -1)
 
 func _ready() -> void:
 	player = get_node(player_path)
@@ -68,7 +69,7 @@ func _refresh() -> void:
 				box.anchor_right = 1.0
 				box.anchor_bottom = 1.0
 
-				var c : Card = board.grids[player][x][y]
+                               var c : Card = board.grids[player][x][y]
 
 				var lbl_name := Label.new()
 				lbl_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -115,16 +116,31 @@ func _refresh() -> void:
 					lbl_eff.text = ""
 				box.add_child(lbl_eff)
 
-				cell.add_child(box)
-				grid.add_child(cell)
-		add_child(grid)
+                               cell.add_child(box)
+                                cell.gui_input.connect(Callable(self, "_on_cell_input").bind(x, y))
+                                grid.add_child(cell)
+                add_child(grid)
 
 	# 3) afficher les structures
 		if player.structures.size() > 0:
 				var head_struct := Label.new()
 				head_struct.text = "Structures:"
 				add_child(head_struct)
-		for s in player.structures:
-			var lbl := Label.new()
-			lbl.text = "[S] %s  (%d PV)" % [s.name, s.hp]
-			add_child(lbl)
+                for s in player.structures:
+                        var lbl := Label.new()
+                        lbl.text = "[S] %s  (%d PV)" % [s.name, s.hp]
+                        add_child(lbl)
+
+func _on_cell_input(event: InputEvent, x: int, y: int) -> void:
+       if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+               if event.pressed:
+                       var c: Card = board.grids[player][x][y]
+                       if c and c.card_type == constants.CardType.UNIT:
+                               selected_from = Vector2i(x, y)
+               else:
+                       if selected_from.x != -1:
+                               board.move_unit(player, selected_from.x, selected_from.y, x, y)
+                               selected_from = Vector2i(-1, -1)
+                               _refresh()
+                               EventBus.emit("board_changed")
+

--- a/ui/details.md
+++ b/ui/details.md
@@ -8,3 +8,6 @@ During play the HUD divides the screen into three bands: `StatsUI` at the top, `
 `BoardUI` builds a grid based on `BoardManager.width` and `height`. A label above the grid shows the player's name followed by life, gold, essence and mana. Each cell is a `Panel` listing the card name, stats and cost. Units display attack and hit points as "atk/hp" while structures show "HP: x".
 
 `HandUI` relies on the same `CardButton` layout. Dragging a card connects to `GameManager.play_card`. Shops and dialogs update through signals such as `hand_changed`, `stats_changed` and `auction_open`. Menus start in a 1280×720 window and switch to 1920×1080 fullscreen when a match begins.
+
+### Controls
+Units can be moved directly on the board. Click a unit to begin a move and then click or drag to the destination tile. `BoardManager.move_unit` checks bounds and emits `board_changed` so all `BoardUI` instances update.


### PR DESCRIPTION
## Summary
- add click & drag movement logic to `BoardUI`
- document unit movement controls

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f050b06c8326bfbbe5925eb79e40