### PR TITLE
Biome shop restock & hand delivery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,7 @@
 This project uses a set of Godot singletons to coordinate gameplay. `GameManager` sits at the center and drives turns, drawing from `Deck` objects and applying effects through `EffectProcessor`. It invokes `BattleManager` when units clash and notifies `BoardManager` so the board refreshes.
 
 `SeasonManager` and `TerrainManager` work together to change the biome each turn. They rebuild tiles and adjust visuals so that cards react to the environment. The `MarketManager` and `BiomeShop` open temporary dialogs allowing players to spend gold between battles. When the auction closes they send results back through `EventBus` signals.
+`SeasonManager.current_biome()` looks up a biome for each season so the `BiomeShop` knows which card pool to draw from.
 
 `NetworkManager` mirrors actions to connected peers using reliable UDP (ENet). Every UI script listens for changes via signals: `BoardUI` tracks the grid, `StatsUI` shows resources and `HandUI` handles drag-and-drop. These panels live under scenes described in `scenes/README.md`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,9 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - Offer helpers like `Logger`, `SaveManager` and `EventBus`.
 - Manage terrain visuals each season through `TerrainManager` and `TerrainTile`.
 - Spawn a `BiomeShop` at every season start so players can buy biome cards.
+- `SeasonManager.current_biome()` maps the active season to a biome name.
+- `BiomeShop` draws four cards from the current biome and any purchase adds the
+  chosen card directly to the buyer's hand.
 
 `GameManager.play_card` emits `hand_changed` so the UI refreshes and calls `BoardManager.remove_dead` after resolving effects. AI opponents call the same method so structures spawn without extra triggers. `BoardManager` rebuilds the grid and emits `board_changed` whenever units move. Tutorial steps use `TutorialManager.start()` and `on_action(tag)`.
 

--- a/scripts/biome_shop.gd
+++ b/scripts/biome_shop.gd
@@ -14,12 +14,16 @@ func _refill():
 	stock = pool.slice(0, size) as Array[Card]
 
 func buy(p:Player, idx:int):
-	if p.gold < 4 or p.essence < 2: return
+	if p.gold < 4 or p.essence < 2:
+		return
 	var c := stock[idx]
 	p.gold    -= 4
 	p.essence -= 2
 	p.emit_stats()
-	p.deck.add(c.copy())
+	var copy := c.copy()
+	p.hand.append(copy)
+	p.emit_signal("hand_changed", p)
 	stock.remove_at(idx)
-	emit_signal("bought", p, c)
-	if stock.is_empty(): _refill()
+	emit_signal("bought", p, copy)
+	if stock.is_empty():
+		_refill()

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -136,7 +136,7 @@ func _on_season_start(_season:int) -> void:
 	terrain.season_update(SeasonManager.current())
 
 	var shop := BiomeShop.new()
-	shop.biome = SeasonManager.current()
+	shop.biome = SeasonManager.current_biome()
 	add_child(shop)
 
 	var dialog : BiomeShopUI = preload("res://scenes/BiomeShopDialog.tscn").instantiate()
@@ -159,8 +159,8 @@ func remote_play_card(_card_id:String, _owner_id:int) -> void:
 			var p := players[_owner_id]
 			for c in p.hand:
 							if c.cid == _card_id:
-											play_card(c, p)
-											break
+				play_card(c, p)
+				break
 
 func remote_end_turn(_owner_id:int) -> void:
 			players[_owner_id].end_turn()

--- a/scripts/season_manager.gd
+++ b/scripts/season_manager.gd
@@ -6,6 +6,12 @@ signal season_end(season   : int)
 signal segment_tick(season : int, segment : int)
 
 const SEGMENTS_PER_SEASON := 4
+const SEASON_BIOMES := {
+	"spring": "Forest",
+	"summer": "Desert",
+	"autumn": "Swamp",
+	"winter": "Tundra"
+}
 var season  : int
 var segment : int
 
@@ -19,6 +25,9 @@ func reset() -> void:
 
 func current() -> String:
 	return constants.SEASON_NAMES[season]
+
+func current_biome() -> String:
+	return SEASON_BIOMES.get(current(), "Forest")
 
 func advance_segment() -> void:
 	segment += 1


### PR DESCRIPTION
## Summary
- add purchased biome cards directly to the buyer's hand
- map seasons to biomes so shops offer the right cards
- document biome mapping in README and docs
- fix indentation (tabs) in shop, game manager and season manager

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd4040848326b7bf2d94bd71e26a