### PR TITLE
Add essence gain per turn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ High level design material lives here so new contributors can quickly understand
 
 ## Structure
 - `architecture.md` outlines how managers and scenes connect and includes small diagrams. Update it whenever systems change.
-- `glossary.md` offers brief definitions of important game terms so discussions stay consistent.
+- `glossary.md` offers brief definitions of important game terms so discussions stay consistent. It notes that players gain one essence each turn.
 - `adr/` stores numbered decision records, beginning with `0001-networking-choice.md` which documents the ENet stack.
 
 Each document should be concise so the folder remains readable. When implementing a new feature, check if any diagrams need updates and add an ADR entry if the change alters the project's direction.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,7 +8,7 @@
 
 **Effect** – A dictionary describing damage, buffs or resource changes processed by `EffectProcessor`.
 
-**Essence** – A resource earned while playing cards; certain abilities spend essence instead of mana.
+**Essence** – A resource gained at the start of each turn; certain abilities spend essence instead of mana.
 
 **Hand** – The set of cards drawn from the deck and displayed with `HandUI`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - `BiomeShop` draws four cards from the current biome and any purchase adds the
   chosen card directly to the buyer's hand.
 
-`GameManager.play_card` emits `hand_changed` so the UI refreshes and calls `BoardManager.remove_dead` after resolving effects. AI opponents call the same method so structures spawn without extra triggers. `BoardManager` rebuilds the grid and emits `board_changed` whenever units move. Tutorial steps use `TutorialManager.start()` and `on_action(tag)`.
+`GameManager.play_card` emits `hand_changed` so the UI refreshes and calls `BoardManager.remove_dead` after resolving effects. AI opponents call the same method so structures spawn without extra triggers. `Player.start_turn` now also grants one essence in addition to resetting mana. `BoardManager` rebuilds the grid and emits `board_changed` whenever units move. Tutorial steps use `TutorialManager.start()` and `on_action(tag)`.
 
 ## Key APIs
 | Script | Functions |

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -43,6 +43,7 @@ func draw(n : int) -> void:
 func start_turn() -> void:
 	Logger.info("start_turn")
 	mana = 3
+	essence += 1
 	draw(5)
 	emit_stats()
 	if !is_human:


### PR DESCRIPTION
## Summary
- award 1 essence to the active player at start of each turn
- mention the resource gain in the glossary
- note the change in scripts and docs readmes

## Testing
- `godot4 --version` *(fails: command not found)*
- `gdformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685705a66d18832697b2452aae7c19d1