### PR TITLE
Improve card effect descriptions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,7 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 | `player.gd` | `draw(n)`, `start_turn()`, `end_turn()`, signal `board_changed(p)` |
 | `season_manager.gd` | `reset()`, `current()`, `advance_segment()` |
 | `effect_processor.gd` | `apply(effect, src, tgt)` |
+| `constants.gd` | `describe_effect(effect)` |
 | Helpers | `Logger.info(msg)`, `SaveManager.save_run(state)` |
 
 Example: when a player uses a card, `GameManager.play_card` updates the board then `NetworkManager` forwards the RPC so peers stay in sync.

--- a/scripts/constants.gd
+++ b/scripts/constants.gd
@@ -6,3 +6,42 @@ enum CardType {UNIT, SPELL, STRUCTURE}
 
 const SEASON_NAMES := ["spring", "summer", "autumn", "winter"]
 const START_LIFE   := 20
+
+# French labels for seasons so UI can display readable effect summaries.
+const SEASON_LABELS := {
+       "spring": "Printemps",
+       "summer": "Été",
+       "autumn": "Automne",
+       "winter": "Hiver",
+}
+
+# Convert a raw effect dictionary into a short human description.
+static func describe_effect(e:Dictionary) -> String:
+       var a := e.get("action", "")
+       var v := e.get("value", 0)
+       match a:
+               "atk":           return "ATK %+d" % v
+               "hp":            return "PV %+d" % v
+               "team_atk":      return "ATK équipe %+d" % v
+               "burn":          return "Brûlure %d" % v
+               "poison":        return "Poison %d" % v
+               "draw":          return "Pioche %d" % v
+               "mana":          return "Mana %+d" % v
+               "gain_gold":     return "Or %+d" % v
+               "charge":        return "Charge %+d" % v
+               "blast":         return "Explosion %d×charge" % v
+               "reset_charge":  return "Réinitialise la charge"
+               "skip_segment":  return "Avance la saison"
+               "extend_season": return "Prolonge la saison"
+               "root":          return "Enracine la cible"
+               "camouflage":    return "Camouflage"
+               "sleep":         return "Endort la cible"
+               "freeze_unit":   return "Gèle la cible"
+               "enemy_atk_mod": return "ATK ennemie %+d" % v
+               "create_token":  return "Crée jeton %s" % e.get("token", "")
+               "consume_token": return "Consomme %s" % e.get("token", "")
+               "duplicate_phantom": return "Double fantôme"
+               "transform":     return "Transforme en %s" % e.get("new_id", "")
+               "penalty_draw":  return "Défausse %d" % (-v)
+               _:
+                       return a

--- a/ui/README.md
+++ b/ui/README.md
@@ -22,7 +22,7 @@ Players can click a unit then select a destination tile to move it. Dragging wor
 | File | Functions | Effect |
 |------|-----------|-------|
 | `tutorial_overlay.gd` | `show_tip(msg)`, `hide()` | Toggle tutorial popups. |
-| `card_button.gd` | signal `dragged(card)` | Emits when dragging a card icon. |
+| `card_button.gd` | signal `dragged(card)` | Emits when dragging a card icon and shows season effect summaries. |
 | Other scripts | *(none)* | Listen for events and refresh the HUD. |
 
 When a card is dragged, `HandUI` forwards the signal to `GameManager.play_card`. Menus run at 1280×720 in windowed mode, then switch to fullscreen at 1920×1080 when a match begins. Full layout notes live in `details.md`.

--- a/ui/card_button.gd
+++ b/ui/card_button.gd
@@ -42,12 +42,15 @@ func _ready() -> void:
 	elif card_data.card_type == constants.CardType.STRUCTURE:
 		stat_text = "HP: %d" % card_data.hp
 
-	var actions : Array[String] = []
-	for key in card_data.effects.keys():
-		var e: Dictionary = card_data.effects[key]
-		actions.append(e.get("action", ""))
+	var effects_text : Array[String] = []
+	for s in constants.SEASON_NAMES:
+		if card_data.effects.has(s):
+		var e: Dictionary = card_data.effects[s]
+		var desc := constants.describe_effect(e)
+		var season := constants.SEASON_LABELS.get(s, s.capitalize())
+		effects_text.append("%s: %s" % [season, desc])
 
-	tooltip_text = "Coût: %d\nStats: %s\n%s" % [cost, stat_text, "\n".join(actions)]
+	tooltip_text = "Coût: %d\nStats: %s\n%s" % [cost, stat_text, "\n".join(effects_text)]
 
 	var box := VBoxContainer.new()
 	box.anchor_left = 0.0
@@ -76,10 +79,10 @@ func _ready() -> void:
 	lbl_cost.text = "Cost: %d" % cost
 	box.add_child(lbl_cost)
 
-	var lbl_eff := Label.new()
-	lbl_eff.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	lbl_eff.text = "Eff: %s" % ", ".join(actions)
-	box.add_child(lbl_eff)
+	       var lbl_eff := Label.new()
+	       lbl_eff.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	       lbl_eff.text = "Eff: %s" % " | ".join(effects_text)
+	       box.add_child(lbl_eff)
 
 	add_child(box)
 	pressed.connect(_on_pressed)


### PR DESCRIPTION
## Summary
- map effect IDs to readable French text via `constants.describe_effect`
- show seasonal effects on card buttons
- document `describe_effect` helper
- mention effect summaries in UI README

## Testing
- `echo "No tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_685709c68cfc83269cc759b5b31596fd