### PR TITLE
Fix card effect overflow

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -14,7 +14,7 @@ UI scripts and scenes live here. They connect menu buttons and HUD nodes to game
 - Use anchored containers so layouts scale with window size.
  - Scripts use tabs for indentation to match Godot defaults.
 
-`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season.
+`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season. CardButton also wraps effect descriptions to keep text inside the button.
 Players can click a unit then select a destination tile to move it. Dragging works too, forwarding the coordinates to `BoardManager.move_unit`.
 `BoardUI` sets `mouse_filter` to `IGNORE` on inner labels so each cell's panel receives the click event.
 

--- a/ui/card_button.gd
+++ b/ui/card_button.gd
@@ -81,6 +81,8 @@ func _ready() -> void:
 
 	var lbl_eff := Label.new()
 	lbl_eff.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	lbl_eff.autowrap_mode = TextServer.AUTOWRAP_WORD
+	lbl_eff.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	lbl_eff.text = "Eff: %s" % " | ".join(effects_text)
 	box.add_child(lbl_eff)
 


### PR DESCRIPTION
## Summary
- wrap effect descriptions inside `CardButton`
- note new wrapping behaviour in `ui/README`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68570cdbbd708326846fc65ea5ef39bc