### PR TITLE
Fix null target in effect processor

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - Manage terrain visuals each season through `TerrainManager` and `TerrainTile`.
 - Spawn a `BiomeShop` at every season start so players can buy biome cards.
 - Apply card effects each season through `GameManager._apply_season_effects`.
+- `EffectProcessor.apply` skips status effects if no target exists to avoid null errors.
 - `SeasonManager.current_biome()` maps the active season to a biome name.
 - `BiomeShop` draws four cards from the current biome and any purchase adds the
   chosen card directly to the buyer's hand.

--- a/scripts/effect_processor.gd
+++ b/scripts/effect_processor.gd
@@ -4,11 +4,19 @@ extends Node
 func apply(e : Dictionary, src : Card, tgt = null) -> void:
 	var a = e.get("action", "")
 	match a:
-		"atk":           tgt.atk += e.value
-		"hp":            tgt.hp  = min(tgt.max_hp, tgt.hp + e.value)
+		"atk":
+			if tgt:
+				tgt.atk += e.value
+		"hp":
+			if tgt:
+				tgt.hp  = min(tgt.max_hp, tgt.hp + e.value)
 		"team_atk":      for u in src.owner.units: u.atk += e.value
-		"burn":          tgt.status.burn   += e.value
-		"poison":        tgt.status.poison += e.value
+		"burn":
+			if tgt:
+				tgt.status.burn   += e.value
+		"poison":
+			if tgt:
+				tgt.status.poison += e.value
 		"draw":          src.owner.draw(e.value)
 		"mana":
 			src.owner.mana += e.value
@@ -23,10 +31,12 @@ func apply(e : Dictionary, src : Card, tgt = null) -> void:
 		"reset_charge":  src.charge = 0
 		"skip_segment":  SeasonManager.advance_segment()
 		"extend_season": SeasonManager.segment = max(0, SeasonManager.segment - 1)
-		"root":          tgt.status.rooted = true
+		"root":          if tgt:
+			tgt.status.rooted = true
 		"camouflage":    src.status.camouflage = true
 		"sleep":         src.status.sleep = 1
-		"freeze_unit":   tgt.status.frozen = 1
+		"freeze_unit":   if tgt:
+			tgt.status.frozen = 1
 		"enemy_atk_mod": for u in src.owner.opponent().units: u.atk += e.value
 		"create_token":  src.owner.summon_token(e.token, e.atk, e.hp)
 		"consume_token": src.owner.consume_token(e.token, e.effect, e.value)


### PR DESCRIPTION
## Summary
- guard against null targets when applying status effects
- document the new safeguard in scripts README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857143177948326a993b946d8c242a6