### PR TITLE
Fix effect processor typing

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,8 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - Apply card effects each season through `GameManager._apply_season_effects`.
 - `EffectProcessor.apply` skips status effects if no target exists to avoid null errors.
 - `Player.draw` assigns owners to drawn cards so spells target correctly.
+- `Card.owner` is typed as `Player` so effects like `enemy_atk_mod` can safely access opponent data.
+- `EffectProcessor.apply` declares `opp: Player` and `idx: int` so Godot can type-check transform effects.
 - `SeasonManager.current_biome()` maps the active season to a biome name.
 - `BiomeShop` draws four cards from the current biome and any purchase adds the
   chosen card directly to the buyer's hand.

--- a/scripts/card.gd
+++ b/scripts/card.gd
@@ -10,7 +10,7 @@ extends Resource
 @export var max_hp   : int
 @export var effects  : Dictionary        # par saison ou clés spéciales
 
-var owner  : Node
+var owner  : Player
 var charge : int = 0
 var status : Dictionary = {
 	"burn":0, "poison":0, "rooted":false, "sleep":0,

--- a/scripts/effect_processor.gd
+++ b/scripts/effect_processor.gd
@@ -39,7 +39,7 @@ func apply(e : Dictionary, src : Card, tgt = null) -> void:
 			tgt.status.frozen = 1
 		"enemy_atk_mod":
 			if src.owner:
-				var opp := src.owner.opponent()
+				var opp: Player = src.owner.opponent()
 				if opp:
 					for u in opp.units:
 						u.atk += e.value
@@ -49,9 +49,10 @@ func apply(e : Dictionary, src : Card, tgt = null) -> void:
 			var d := src.copy(); d.atk = 0; d.hp = 1; d.owner = src.owner
 			src.owner.units.append(d)
 		"transform":
-			var rep : Card = CardDatabase.neutral().filter(func(c): return c.cid == e.new_id)[0].copy()
-			var idx := src.owner.structures.find(src)
-			if idx != -1: src.owner.structures[idx] = rep
+			var rep: Card = CardDatabase.neutral().filter(func(c): return c.cid == e.new_id)[0].copy()
+			var idx: int = src.owner.structures.find(src)
+			if idx != -1:
+				src.owner.structures[idx] = rep
 		"penalty_draw":  src.owner.draw(e.value)          # value négatif
 		_:
 			Logger.warn("Unknown effect: %s" % a)


### PR DESCRIPTION
## Summary
- fix typing for enemy attack modifier and transform effects
- store Player reference in Card.owner
- document typed owner in scripts README
- document typed variables in EffectProcessor
- fix tab indentation in effect processor

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571cb76dd8832687b0df5c5ca669e0