### PR TITLE
Add market bidding UI

### DIFF
--- a/scenes/MarketDialog.tscn
+++ b/scenes/MarketDialog.tscn
@@ -8,3 +8,11 @@ script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
 text = "Texte enchère"
+
+[node name="BidAmount" type="SpinBox" parent="."]
+min_value = 0.0
+max_value = 99.0
+step = 1.0
+
+[node name="BidButton" type="Button" parent="."]
+text = "Miser"

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -22,7 +22,7 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 | `LobbyMenu.tscn` | Connects peers and displays player list. |
 | `Main.tscn` | Contains battle board, managers and a background. |
 | `HistoryUI.tscn` | Panel showing the action log on the right side. |
-| `MarketDialog.tscn` | Popup for the neutral auction house. |
+| `MarketDialog.tscn` | Auction popup with a bid `SpinBox` and "Miser" button. |
 | `BiomeShopDialog.tscn` | Popup showing seasonal cards at the start of each season. |
 | `TerrainTile.tscn` | Visual tile with drop shadow, a transparent `Control` overlay and a `Label` that shows the biome name. |
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -8,6 +8,7 @@ UI scripts and scenes live here. They connect menu buttons and HUD nodes to game
 - Provide `MainMenu` and `LobbyMenu` for solo or online play.
 - Show resources and the end-turn button through `StatsUI`.
 - Support drag and drop via `CardButton` and open dialogs such as `MarketDialog`.
+- `MarketDialog` propose un `SpinBox` pour miser et un bouton "Miser" qui envoie la mise.
 - `BiomeShopUI` lists seasonal cards and hooks to `BiomeShop`.
 - Spawn `HandUI` and `StatsUI` only for human players to avoid AI HUD clutter.
 - Offer tutorial hints through `TutorialOverlay`.

--- a/ui/market_dialog.gd
+++ b/ui/market_dialog.gd
@@ -3,6 +3,8 @@ class_name MarketDialog
 
 @export var market_path : NodePath
 var market : MarketManager
+@onready var amount : SpinBox = $BidAmount
+@onready var bid_btn : Button = $BidButton
 
 func _ready() -> void:
 	market = get_node(market_path)
@@ -10,6 +12,8 @@ func _ready() -> void:
 	# Godot 4 : connect(signal_name : String, callable : Callable)
 	market.connect("auction_open",  Callable(self, "_on_open"))
 	market.connect("auction_close", Callable(self, "_on_close"))
+	bid_btn.pressed.connect(_on_bid_pressed)
+	confirmed.connect(_on_confirmed)
 
 # ------------------------------------------------------------- callbacks
 func _on_open(card : Card) -> void:
@@ -19,3 +23,11 @@ func _on_open(card : Card) -> void:
 
 func _on_close(card : Card, winner : Player) -> void:
 	visible = false
+
+func _on_bid_pressed() -> void:
+	var player := get_tree().get_first_node_in_group("local_player")
+	if player:
+	market.bid(player, int(amount.value))
+
+func _on_confirmed() -> void:
+	market.close()


### PR DESCRIPTION
## Summary
- add SpinBox and bid button to MarketDialog.tscn
- connect the button in `market_dialog.gd` and close the auction on confirm
- document new bid controls in `ui/README.md`
- update scenes README for updated MarketDialog description

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857225eaf6c8326b0323e0d89710678