### PR TITLE
Reference effect textures

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -17,6 +17,7 @@ Use PNGs at power-of-two sizes so textures scale well. When adding new icons, cr
 | `cards/` | frames such as `forest_card.png` and `neutral_structure.png` |
 | `ui/` | icons including `gold.png`, `mana.png`, `burn.png` |
 | `terrain/` | simple 64×64 textures for each biome *(omitted from repository)* |
+| `effects/` | placeholder effects (`spawn_effect.png`, `attack_effect.png`, `destroy_effect.png`) *(not included in repository)* |
 
 
 Large sprite sheets or sounds should live in a subfolder and be referenced by a scene so they are loaded only when necessary. Keeping this folder clean helps reduce build size and keeps git history manageable.

--- a/scenes/CardButton.tscn
+++ b/scenes/CardButton.tscn
@@ -5,3 +5,5 @@
 [node name="CardButton" type="Button"]
 size_flags_horizontal = 3
 script = ExtResource("1")
+
+[node name="Anim" type="AnimationPlayer" parent="."]

--- a/scenes/README.md
+++ b/scenes/README.md
@@ -24,7 +24,8 @@ Scenes describe the node hierarchy for menus, gameplay and popups. They remain l
 | `HistoryUI.tscn` | Panel showing the action log on the right side. |
 | `MarketDialog.tscn` | Auction popup with a bid `SpinBox` and "Miser" button. |
 | `BiomeShopDialog.tscn` | Popup showing seasonal cards at the start of each season. |
-| `TerrainTile.tscn` | Visual tile with drop shadow, a transparent `Control` overlay and a `Label` that shows the biome name. |
+| `TerrainTile.tscn` | Visual tile with drop shadow, a transparent `Control` overlay and a `Label` that shows the biome name. Includes an `AnimationPlayer` for spawn and battle effects. |
+| `CardButton.tscn` | Button used in `HandUI` to display cards. Now has an `AnimationPlayer` so GameManager can animate plays. |
 
 
 Scenes rarely contain code beyond hooking up their child nodes. When adding a new scene, keep scripts minimal and delegate behaviour to a manager in `scripts/` or UI controller in `ui/` so the structure stays maintainable.

--- a/scenes/TerrainTile.tscn
+++ b/scenes/TerrainTile.tscn
@@ -22,4 +22,6 @@ position = Vector2(0, -14)
 horizontal_alignment = 1
 text = ""
 
+[node name="Anim" type="AnimationPlayer" parent="."]
+
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,9 @@ Gameplay logic and autoloaded singletons live here. Keeping them together lets m
 - Provide AI routines and network RPCs through `NetworkManager`.
 - Offer helpers like `Logger`, `SaveManager` and `EventBus`.
 - Manage terrain visuals each season through `TerrainManager` and `TerrainTile`.
+- Trigger tile animations through `BattleManager` and `GameManager` when cards
+  spawn, attack or die.
+- Tile scripts load placeholder textures from `assets/effects/` if present.
 - Spawn a `BiomeShop` at every season start so players can buy biome cards.
 - Apply card effects each season through `GameManager._apply_season_effects`.
 - `EffectProcessor.apply` skips status effects if no target exists to avoid null errors.

--- a/scripts/battle_manager.gd
+++ b/scripts/battle_manager.gd
@@ -7,9 +7,13 @@ static func destroy(c : Card) -> void:
 	if c in o.units:      o.units.erase(c)
 	elif c in o.structures: o.structures.erase(c)
 	EventBus.emit("card_destroyed", {"card": c})
+	var tile := _tile_for(c)
+	if tile:
+		tile.play_destroy()
 
 # ------------------------------------------------------- combat helpers
 static func unit_vs_unit(a:Card, d:Card) -> void:
+	_play_attack(a, d)
 	d.damage(a.atk)
 	if d.hp > 0:
 		a.damage(d.atk)
@@ -28,3 +32,20 @@ static func full_attack(att:Player, def:Player) -> void:
 			def.take_direct_dmg(u.atk)
 			EventBus.emit("history", {"msg": "%s attaque %s directement" % [u.name, def.name]})
 		i += 1
+
+static func _play_attack(a:Card, d:Card) -> void:
+	var ta := _tile_for(a)
+	if ta:
+		ta.play_attack()
+	var td := _tile_for(d)
+	if td:
+		td.play_attack()
+
+static func _gm() -> GameManager:
+	return (Engine.get_main_loop() as SceneTree).root.get_node("Main")
+
+static func _tile_for(c:Card) -> TerrainTile:
+	var info := _gm().board.find_card(c)
+	if info.has("player"):
+		return _gm().terrain.tiles[info["player"]][info["x"]][info["y"]]
+	return null

--- a/scripts/board_manager.gd
+++ b/scripts/board_manager.gd
@@ -63,3 +63,11 @@ func remove_dead():
 					Logger.info("%s destroyed at %d,%d" % [c.name, x, y])
 					c.owner.emit_board()
 					EventBus.emit("board_changed")
+
+func find_card(card:Card) -> Dictionary:
+	for p in grids:
+		for x in width:
+			for y in height:
+				if grids[p][x][y] == card:
+					return {"player": p, "x": x, "y": y}
+	return {}

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -34,7 +34,10 @@ func play_card(card:Card, p:Player) -> void:
 	else:
 		var pos := _find_slot(p)
 		if pos.x >= 0:
-			board.place_card(p, card, pos.x, pos.y)
+			if board.place_card(p, card, pos.x, pos.y):
+				var tile := terrain.tiles[p][pos.x][pos.y]
+				if tile:
+					tile.play_spawn()
 			board.remove_dead()
 
 	EventBus.emit("history", {"msg": "%s plays %s" % [p.name, card.name]})

--- a/scripts/terrain_tile.gd
+++ b/scripts/terrain_tile.gd
@@ -18,6 +18,11 @@ var _base_color : Color = Color.WHITE
 @onready var shadow : Sprite2D = $Shadow
 @onready var clickable : Control = $Clickable
 @onready var lbl_biome : Label = $Label
+@onready var anim : AnimationPlayer = $Anim
+
+const EFFECT_SPAWN_PATH := "res://assets/effects/spawn_effect.png"
+const EFFECT_ATTACK_PATH := "res://assets/effects/attack_effect.png"
+const EFFECT_DESTROY_PATH := "res://assets/effects/destroy_effect.png"
 
 func _ready() -> void:
 	set_biome(biome)
@@ -61,3 +66,30 @@ func _on_mouse_entered() -> void:
 
 func _on_mouse_exited() -> void:
 	highlight(false)
+
+func play_spawn() -> void:
+	scale = Vector2.ZERO
+	create_tween().tween_property(self, "scale", Vector2.ONE, 0.2)
+	_show_effect(EFFECT_SPAWN_PATH)
+
+func play_attack() -> void:
+	var tw := create_tween()
+	tw.tween_property(self, "scale", Vector2.ONE * 1.2, 0.1)
+	tw.tween_property(self, "scale", Vector2.ONE, 0.1)
+	_show_effect(EFFECT_ATTACK_PATH)
+
+func play_destroy() -> void:
+	create_tween().tween_property(self, "modulate:a", 0.0, 0.2)
+	_show_effect(EFFECT_DESTROY_PATH)
+
+func _show_effect(path:String) -> void:
+	var tex := load(path)
+	if tex == null:
+	return
+	var s := Sprite2D.new()
+	s.texture = tex
+	s.centered = true
+	add_child(s)
+	var tw := create_tween()
+	tw.tween_property(s, "modulate:a", 0.0, 0.25)
+	tw.tween_callback(Callable(s, "queue_free"))

--- a/ui/README.md
+++ b/ui/README.md
@@ -15,7 +15,7 @@ UI scripts and scenes live here. They connect menu buttons and HUD nodes to game
 - Use anchored containers so layouts scale with window size.
  - Scripts use tabs for indentation to match Godot defaults.
 
-`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season. CardButton also wraps effect descriptions to keep text inside the button.
+`StatsUI` spans the top, `BoardsPanel` holds one `BoardUI` per player in the middle and `HandUI` stays at the bottom. `HistoryUI` occupies the right edge. Signals like `hand_changed`, `board_changed` and `auction_open` keep every panel in sync. BoardUI also shows life, gold, essence and mana under each player's name. Each card preview uses the same `CardButton` layout so stats and costs stay consistent. `BiomeShopUI` hides after a purchase and the shop refills before the next season. CardButton also wraps effect descriptions to keep text inside the button. `CardButton.tscn` now embeds an `AnimationPlayer` for spawn and destroy cues. `CardButton` and `TerrainTile` display small textures from `assets/effects/` when available.
 Players can click a unit then select a destination tile to move it. Dragging works too, forwarding the coordinates to `BoardManager.move_unit`.
 `BoardUI` sets `mouse_filter` to `IGNORE` on inner labels so each cell's panel receives the click event.
 

--- a/ui/card_button.gd
+++ b/ui/card_button.gd
@@ -5,6 +5,11 @@ class_name CardButton
 ## Il gère le drag-and-drop d’une carte depuis la main vers le plateau.
 
 var card_data : Card
+@onready var anim : AnimationPlayer = $Anim
+
+const EFFECT_SPAWN_PATH := "res://assets/effects/spawn_effect.png"
+const EFFECT_ATTACK_PATH := "res://assets/effects/attack_effect.png"
+const EFFECT_DESTROY_PATH := "res://assets/effects/destroy_effect.png"
 
 # Percentage of the screen width this button should occupy.
 @export var size_ratio : float = 0.1
@@ -95,3 +100,30 @@ func _gui_input(event : InputEvent) -> void:
 
 func _on_pressed() -> void:
 	emit_signal("dragged", card_data)
+
+func play_spawn() -> void:
+	scale = Vector2.ZERO
+	create_tween().tween_property(self, "scale", Vector2.ONE, 0.2)
+	_show_effect(EFFECT_SPAWN_PATH)
+
+func play_attack() -> void:
+	var tw := create_tween()
+	tw.tween_property(self, "scale", Vector2.ONE * 1.2, 0.1)
+	tw.tween_property(self, "scale", Vector2.ONE, 0.1)
+	_show_effect(EFFECT_ATTACK_PATH)
+
+func play_destroy() -> void:
+	create_tween().tween_property(self, "modulate:a", 0.0, 0.2)
+	_show_effect(EFFECT_DESTROY_PATH)
+	
+func _show_effect(path:String) -> void:
+	var tex := load(path)
+	if tex == null:
+	return
+	var s := Sprite2D.new()
+	s.texture = tex
+	s.centered = true
+	add_child(s)
+	var tw := create_tween()
+	tw.tween_property(s, "modulate:a", 0.0, 0.25)
+	tw.tween_callback(Callable(s, "queue_free"))


### PR DESCRIPTION
## Summary
- load spawn, attack and destroy effect textures in tile and card scripts
- show effect sprites during spawn, attack and destroy animations
- document the new effect files in READMEs

## Testing
- `ls tests || true`


------
https://chatgpt.com/codex/tasks/task_e_6857f6d6236c8326838f21ab8af36ef6